### PR TITLE
V4 design system: auto-ecomm

### DIFF
--- a/handoff/auto-ecomm.md
+++ b/handoff/auto-ecomm.md
@@ -1,0 +1,61 @@
+# Design-system-applier handoff — auto-ecomm
+
+## Top-level flag (read this first)
+
+**This case is not ready for the design system pass.** The polished draft at `drafts/auto-ecomm.mdx` is a structural skeleton of TODO comments with no body prose. The composer's previous round did not produce real content. Both the composer and copywriter handoff notes in that draft say so explicitly:
+
+- Composer: "It is meant to be replaced wholesale once raw material and an interview transcript are added."
+- Copywriter: "Status: nothing to polish… The draft is a structural skeleton of TODO comments with no body prose."
+
+My hard rules forbid me from writing the case from the raw `.docx` files (the four files in `raw-case-material/auto-ecomm/`, which include the Fjord PDF and three Whitney drafts the critic verified decode cleanly). "Do not modify the prose. Do not invent content."
+
+What I produced is therefore a **V4-shelled placeholder**: V4 frontmatter shape, V4 imports, the SpecimenSignoff in the right place, and the existing TODO comments preserved verbatim. `status` stays `'draft'`. It will render as a near-empty page if built; that is intentional. **Do not ship.**
+
+The unblock, per the copywriter, is: re-run the composer in Origin mode against the raw material that is in fact present in `raw-case-material/auto-ecomm/`. Then critic, then copywriter, then re-run me.
+
+## Layout archetype
+
+**Hybrid, leaning 6-section.** Picked provisionally so the skeleton has a recognizable V4 shape; the real archetype call belongs to the next composer + applier round once the case has prose.
+
+Reason: the copywriter's preview of the spine (ethnography + reframe + butcher-paper readout) sounds 6-section to me — narrative-led, fewer artifacts, one strong reframe — but the Fjord PDF may reveal enough research density to push it to 12-section. Re-decide once content lands.
+
+## Components used (count 5 of 6 cap)
+
+- **StatRow** (top of body) — V4 archetype opener; left as TODO/TODO so it visibly demands real metrics before publish.
+- **PullQuote** (after "The turn" section) — placeholder, attribution and body both TODO. Copywriter flagged "Behind the Line of Visibility" as the obvious anchor for the next round.
+- **BotanicalDivider** (between turn and design response) — single inline divider, matches the V4 botanical exception system.
+- **InsightCallout** (after "What we did about it") — placeholder for the one design principle that should fall out of the reframe.
+- **SpecimenSignoff** (very bottom) — required V4 end-of-case ornament. Path is a TODO placeholder.
+
+I deliberately did not import or use `DarkBand` or `ProcessTimeline`: nothing in the (nonexistent) prose justifies them yet. Adding them would be inventing structural intent.
+
+## Specimen choice
+
+**TBD — left as `/images/specimen-TBD.jpg` and `/images/signoff-TBD.png` in the frontmatter.**
+
+Reason: the design system rule (V3 PDF section 04, carried into V4) is that the specimen carries thematic weight from the case's spine. The auto-ecomm spine isn't fixed yet — depending on whether the final framing leans on dealership ethnography, the data-integrity reframe, or the cross-channel customer journey, a different botanical will fit. The composer handoff explicitly held this decision: "Specimen assignment also TBD; should be picked once the case's spine is set so the botanical motif carries thematic weight."
+
+When the next round picks one, update both `specimen` and `specimenSignoff` in the MDX frontmatter, and the `<SpecimenSignoff specimen="…" />` path at the bottom of the file.
+
+## Image assets referenced (TODO — Whitney to upload)
+
+- `/images/specimen-TBD.jpg` — cover specimen, not yet chosen
+- `/images/signoff-TBD.png` — end-of-case ornament, not yet chosen
+
+No in-body imagery is referenced because there is no in-body prose to anchor it to. The Fjord PDF in `raw-case-material/auto-ecomm/` reportedly contains dealership and synthesis-wall photography; those become candidates for `DarkBand` figures once a real draft exists.
+
+## Narrative content that didn't fit V4 vocabulary
+
+None — there is no narrative content to fit. All structural moments are TODO comments, preserved verbatim from the polished draft so the next composer round can drop prose into them without rebuilding the spine.
+
+## Open questions for Whitney
+
+1. **Confirm this case should proceed at all.** The composer's round 1 open question still stands: is `auto-ecomm` a portfolio case Whitney wants to ship, or one she's testing whether to include? The framing of the next composer round depends on the answer.
+2. **Confirm client identity and NDA posture.** Copywriter notes treat AutoNation / Fjord / Accenture as the spine. If any of that needs anonymizing, decide before the next composer pass so the prose lands in the right register.
+3. **Time-horizon framing.** The critic flagged this as one of two upstream calls only Whitney can make: own the era vs. lead with a "what I'm still carrying forward" through-line. Affects opening tone.
+4. **Scope honesty.** The critic also flagged: this engagement produced research, journeys, and a roadmap — not a shipped launch unless new evidence surfaces. Outcomes section needs to be framed accordingly.
+5. **Specimen selection.** Pick after the spine is set. See specimen section above.
+
+## Recommendation
+
+Move this PR back to `composer-needed` (or whatever the equivalent label is) before merging. The MDX I produced will render but says nothing; shipping it as-is would put a TODO-titled page on the live site.

--- a/src/content/cases/auto-ecomm.mdx
+++ b/src/content/cases/auto-ecomm.mdx
@@ -1,0 +1,90 @@
+---
+title: 'TODO: Auto e-commerce case title <em>(awaiting real composer pass)</em>'
+client: 'TODO: Likely AutoNation (per copywriter notes); confirm before publish'
+year: 2026
+role: "TODO: Whitney's role on the project"
+team: 'TODO: Team composition (Fjord with Accenture per copywriter notes)'
+timeline: 'TODO: Project timeline'
+tags:
+  - 'Service Design'
+  - 'Ethnographic Research'
+  - 'E-commerce'
+  - 'Automotive'
+summary: 'TODO: One-sentence summary for the work grid card.'
+specimen: '/images/specimen-TBD.jpg'
+specimenSignoff: '/images/signoff-TBD.png'
+slug: 'auto-ecomm'
+status: 'draft'
+---
+import StatRow from '../../components/StatRow.astro';
+import PullQuote from '../../components/PullQuote.astro';
+import InsightCallout from '../../components/InsightCallout.astro';
+import BotanicalDivider from '../../components/BotanicalDivider.astro';
+import SpecimenSignoff from '../../components/SpecimenSignoff.astro';
+
+<StatRow stats={[
+  { value: 'TODO', label: 'TODO: meaningful metric' },
+  { value: 'TODO', label: 'TODO: meaningful metric' },
+  { value: 'TODO', label: 'TODO: meaningful metric' },
+  { value: 'TODO', label: 'TODO: meaningful metric' },
+]} />
+
+## The question
+
+{/* TODO: Open with the real tension this project surfaced. Not "the client wanted a
+    better e-commerce experience" — the actual organizational or human problem
+    underneath. The opening should make a non-designer reader (a marketing or ops
+    leader) feel the stakes inside three paragraphs. */}
+
+## The situation
+
+{/* TODO: What was the project, who was the client, when did it run, and what was
+    Whitney's specific role? Two or three paragraphs. Per copywriter notes, the
+    spine is: AutoNation, Fjord with Accenture, two weeks of dealership
+    ethnography, "Behind the Line of Visibility" reframe to internal data
+    integrity, mid-engagement coaching of Accenture researchers, unannounced
+    client readout handled on butcher paper. Confirm and refine the frontmatter
+    once this is written. */}
+
+## TODO: Methodology / fieldwork section
+
+{/* TODO: Lead with the choice that mattered, not the sequence of steps. Two
+    weeks of dealership ethnography is the core craft moment per copywriter
+    notes. */}
+
+## TODO: The turn
+
+{/* TODO: The "Behind the Line of Visibility" reframe — from a customer-facing
+    e-commerce problem to an internal data-integrity problem — is the obvious
+    pull-quote anchor for the next round. Find the actual moment a participant
+    or stakeholder put it into words. */}
+
+<PullQuote attribution="TODO: source and role">
+  TODO: A real quote from research, a stakeholder, or Whitney's notes that captures the turn or the central tension.
+</PullQuote>
+
+<BotanicalDivider />
+
+## TODO: What we did about it
+
+{/* TODO: The design response. The butcher-paper readout is the obvious craft
+    moment to quote. Specific enough that a peer service designer can see the
+    craft. */}
+
+<InsightCallout label="TODO: principle label">
+  TODO: One design principle or strategic reframe that came out of this work, in
+  Whitney's voice. The kind of line a hiring manager would underline.
+</InsightCallout>
+
+## TODO: Outcomes
+
+{/* TODO: What changed because of this work. Numbers where possible, plain
+    qualitative statements where not. Per critic notes, this engagement
+    produced research, journeys, and a roadmap — not a shipped launch unless
+    evidence surfaces. Frame outcomes accordingly. */}
+
+## What I'm carrying forward
+
+{/* TODO: Two to four short reflections, each a single sharp paragraph. */}
+
+<SpecimenSignoff specimen="/images/signoff-TBD.png" />

--- a/src/content/cases/auto-ecomm.mdx
+++ b/src/content/cases/auto-ecomm.mdx
@@ -21,6 +21,20 @@ import PullQuote from '../../components/PullQuote.astro';
 import InsightCallout from '../../components/InsightCallout.astro';
 import BotanicalDivider from '../../components/BotanicalDivider.astro';
 import SpecimenSignoff from '../../components/SpecimenSignoff.astro';
+import Placeholder from '../../components/Placeholder.astro';
+
+<Placeholder
+  kind="image"
+  size="hero"
+  ask="Hero image: AutoNation dealership lot or showroom interior (period-correct, late-2000s California)"
+  why="V4 frontmatter has no hero_image; the case's spine is two weeks of dealership ethnography and a hero grounds the reader in the field site before the reframe lands"
+  alternatives={[
+    "Synthesis-wall photo extracted from the Fjord PDF in raw-case-material/auto-ecomm/ (critic confirmed dealership and synthesis-wall imagery is in the PDF)",
+    "Hand-drawn butcher-paper readout artifact, photographed — leans craft-moment instead of field-site",
+    "Period stock photo of a U.S. dealership lot"
+  ]}
+  source="visual-director-recommendation"
+/>
 
 <StatRow stats={[
   { value: 'TODO', label: 'TODO: meaningful metric' },
@@ -28,6 +42,17 @@ import SpecimenSignoff from '../../components/SpecimenSignoff.astro';
   { value: 'TODO', label: 'TODO: meaningful metric' },
   { value: 'TODO', label: 'TODO: meaningful metric' },
 ]} />
+
+<Placeholder
+  kind="stat"
+  size="stat-cell"
+  ask="Real values for all four StatRow cells — candidates: # of dealerships shadowed (3), weeks of fieldwork (2), # of Accenture researchers mentored mid-engagement (3), minutes salespeople left customers to physically locate a car (~45)"
+  why="The StatRow currently opens the page with four TODO/TODO cells; until real numbers land, the V4 archetype opener is empty"
+  alternatives={[
+    "Drop the StatRow entirely if the engagement doesn't generate four clean countable artifacts — narrative-led 6-section archetype supports omitting it",
+    "Reduce to two or three cells with the strongest numbers"
+  ]}
+/>
 
 ## The question
 
@@ -52,6 +77,19 @@ import SpecimenSignoff from '../../components/SpecimenSignoff.astro';
     weeks of dealership ethnography is the core craft moment per copywriter
     notes. */}
 
+<Placeholder
+  kind="image"
+  size="in-body-figure"
+  ask="Dealership ethnography photo: salesperson on the lot, customer waiting at a desk, or service-bay queue from one of the three California sites"
+  why="The methodology section will describe two weeks of dealership ethnography across three sites; an image grounds the field site and breaks up what is otherwise a prose-only section"
+  alternatives={[
+    "Dealership or synthesis-wall photo extracted from the Fjord PDF in raw-case-material/auto-ecomm/",
+    "Photo of the butcher-paper readout artifact (preliminary themes hand-drawn, deliberately rough)",
+    "Service blueprint sketch or scan from Whitney's notes"
+  ]}
+  source="visual-director-recommendation"
+/>
+
 ## TODO: The turn
 
 {/* TODO: The "Behind the Line of Visibility" reframe — from a customer-facing
@@ -62,6 +100,17 @@ import SpecimenSignoff from '../../components/SpecimenSignoff.astro';
 <PullQuote attribution="TODO: source and role">
   TODO: A real quote from research, a stakeholder, or Whitney's notes that captures the turn or the central tension.
 </PullQuote>
+
+<Placeholder
+  kind="quote"
+  size="block"
+  ask="The 'Behind the Line of Visibility' line as it appears in the firm-published Fjord PDF — attributed to Whitney or the Fjord team, framing the reframe from customer-facing e-commerce to internal data integrity"
+  why="The PullQuote slot is currently TODO and this is the anchor both the critic and copywriter independently flagged as the obvious one"
+  alternatives={[
+    "A field quote from a salesperson or AutoNation stakeholder about the 45-minute physical car-locate problem — leans evidence rather than thesis",
+    "Leave the PullQuote out and let the reframe land in body prose if the next composer round handles it well inline"
+  ]}
+/>
 
 <BotanicalDivider />
 
@@ -83,8 +132,46 @@ import SpecimenSignoff from '../../components/SpecimenSignoff.astro';
     produced research, journeys, and a roadmap — not a shipped launch unless
     evidence surfaces. Frame outcomes accordingly. */}
 
+<Placeholder
+  kind="section"
+  size="block"
+  ask="When this section gets prose, frame outcomes around research / customer journeys / roadmap of opportunities — and explicitly avoid implying a shipped 'first online dealership' launch unless new evidence surfaces"
+  why="Critic flagged: 'The next draft must not imply a shipped outcome it cannot evidence; the value claim should sit on the reframe and the roadmap, not on a launch.'"
+  alternatives={[
+    "A single sentence acknowledging that AutoNation became the first online-purchase dealership only if Whitney can verify the launch shipped",
+    "Lead the section with the roadmap and treat the reframe-acceptance by the AutoNation execs as the load-bearing outcome"
+  ]}
+  source="critic-flag"
+/>
+
 ## What I'm carrying forward
 
 {/* TODO: Two to four short reflections, each a single sharp paragraph. */}
+
+## What I need from you
+
+This section is scaffolding from the visual-director agent. Delete it before publishing.
+
+**Top-level note:** this case is a TODO scaffold, not a draft. The composer never ingested the real raw material (Fjord PDF + three Whitney .docx files in `raw-case-material/auto-ecomm/`) and the design-system-applier handoff explicitly says *"Do not ship."* The asset asks below assume a re-run of composer → critic → copywriter → applier first; until then, every placeholder below is provisional.
+
+### Images (3)
+
+- **Hero image** — a period-correct AutoNation dealership exterior or showroom interior. *Where:* top of body, before the StatRow. *Source:* `raw-case-material` first (Fjord PDF reportedly contains dealership and synthesis-wall photography per the critic) → `human-capture` only if no usable frame exists. *Alternatives:* synthesis-wall photo from the PDF; butcher-paper readout artifact photographed; period stock dealership lot.
+- **In-body fieldwork figure** — salesperson on the lot, customer waiting, or service-bay queue from one of the three California dealerships. *Where:* methodology / fieldwork section. *Source:* `raw-case-material` (extract from Fjord PDF). *Alternatives:* photo of the butcher-paper readout artifact; service blueprint sketch from Whitney's notes.
+- **Specimen + signoff botanicals** — currently `specimen-TBD.jpg` / `signoff-TBD.png`. *Where:* frontmatter + `<SpecimenSignoff />` at the bottom. *Source:* `human-capture` once the spine is set (per design-system-applier handoff, the botanical motif should carry thematic weight from the case's spine — pick after composer round 2).
+
+### Stat values (1 cluster — 4 cells)
+
+- **All four StatRow cells** — every cell currently reads `TODO` / `TODO: meaningful metric`. *Where:* the StatRow at the top of the body. *Source:* the Fjord PDF and the three Whitney .docx files in `raw-case-material/auto-ecomm/`. Candidate numbers from the critic's read of the raw material: 3 dealerships shadowed, 2 weeks of fieldwork, 3 Accenture researchers mentored mid-engagement, ~45 minutes salespeople left customers to physically locate cars. If four clean numbers don't surface, drop the StatRow — the 6-section archetype the applier picked supports omitting it.
+
+### Pull quotes (1)
+
+- **"Behind the Line of Visibility"** — the firm-published phrase that names the reframe. *Source:* the Fjord PDF in `raw-case-material/auto-ecomm/` (verify exact wording and surrounding context). The PullQuote slot is currently TODO; both the critic and copywriter independently named this as the anchor.
+
+### Sections to add (per critic) (3)
+
+- **Lead with the reframe, not the methodology** — *critic, high:* "a digital-channel mandate that fieldwork re-scoped to an internal-operations problem… the opening should put a non-designer reader inside that re-scoping decision in three paragraphs." *Where:* the opening of "The question" + "The situation." This is a structural call for the next composer round, not a slot a placeholder can hold.
+- **Scope honesty in Outcomes** — *critic, medium:* engagement produced research, journeys, themes, and a roadmap; do not imply a shipped "first online dealership" launch unless evidence surfaces. *Where:* the Outcomes section (placeholder dropped inline above).
+- **Time-horizon framing** — *critic, medium:* either own the era or lead with a "what I'm still carrying forward" through-line. *Where:* affects opening tone and the "What I'm carrying forward" closing. This is Whitney's call before the next composer round, not a section a placeholder can scaffold.
 
 <SpecimenSignoff specimen="/images/signoff-TBD.png" />


### PR DESCRIPTION
Applies V4 portfolio design system to the polished draft from Agent-Land PR #15 (https://github.com/whitneyesque/Agent-Land/pull/15). Handoff notes (component choices, image-asset TODOs, open questions) are in the HTML comment at the bottom of src/content/cases/auto-ecomm.mdx. To preview locally: cd ~/dev/whitneyesque.github.io && git fetch origin && git checkout design-system/auto-ecomm-15 && npm install && npm run dev — then open http://localhost:4321/cases/auto-ecomm