### PR TITLE
V4 design system: ecomm

### DIFF
--- a/handoff/ecomm.md
+++ b/handoff/ecomm.md
@@ -1,0 +1,74 @@
+# Design-system-applier handoff — ecomm
+
+## Status flag (read this first)
+
+This case is **not ready to ship.** The polished draft at `agent-land/drafts/ecomm.mdx` is a structural placeholder, not a draft. Every section body is a TODO instruction written to the next composer round, not prose meant for a reader. The composer, critic, and copywriter all explicitly declined to fill it in:
+
+- **Composer (round 1):** Could not draft; flagged that `raw-case-material/ecomm/` has only `Ecommerce - Case Study.pdf` and no `CASE-CONTEXT.md`, `whitney-notes.md`, `interview-transcript.md`, or artifacts.
+- **Critic:** Caught the composer's factual error about the folder being empty (the PDF exists), AND raised an upstream gating question — whether this case belongs in the portfolio at all, given the work as currently described reads as junior IXD support rather than service design.
+- **Copywriter (round 1):** Declined to polish anything because there is no prose to polish. Polishing TODO instructions would be theatre.
+
+The MDX I produced applies V4 structure to the placeholder so the file lints, schema-validates, and renders as a draft. It does **not** make the case ready to ship.
+
+`status: 'draft'` is set deliberately. Per `src/content/config.ts`, draft cases are built but not linked from the work page. **Do not flip to `'published'` until the gating decision is made and an interview-driven composer round produces real prose.**
+
+## Layout archetype
+
+**6-section.**
+
+Reason: the polished placeholder uses agetech's 6-section scaffold (Question → Situation → What we did → Evidence → Decision/outcome → Carrying forward). I preserved that shape verbatim because (a) the prose is locked by the upstream pipeline, and (b) the case has no spine yet — committing to the 12-section archetype would be inventing structure the case hasn't earned. When real material lands the next composer round can either keep this shape or reshape into the 12-section archetype if research/process density justifies it.
+
+## Components used (count 4 of 6 cap)
+
+- **StatRow** — bottom of "The decision / outcome" section. Three TODO metric slots, structurally identical to the polished draft. **API converted from V3 children syntax (`<StatRow><Stat value=... label=... /></StatRow>`) to V4 props syntax (`stats={[{value, label}, ...]}`).** This was a structural compatibility fix; the underlying `StatRow.astro` component on this branch only accepts the props form. Without this fix the file would not have rendered.
+- **PullQuote** — "Evidence" section. Single TODO quote with a TODO attribution. Mirrors the agetech and ferguson-cx pattern of one decisive pullquote per case.
+- **InsightCallout** — middle of "What we did" section. TODO-labelled callout for the case's central design principle once it surfaces. **Removed the `tone="cerulean"` prop the polished draft passed** — the V4 `InsightCallout.astro` component on this branch does not accept a tone prop, and the two reference V4 cases (agetech, ferguson-cx) do not use one. Astro silently ignores unknown props, but cleaner to drop.
+- **SpecimenSignoff** — at the very end of the file, before EOF. Required V4 closer per the agent definition's hard rule. Passes `specimen="/images/signoff-camellia.png"` (see Specimen choice below).
+
+Components considered and **not** added:
+- **BotanicalDivider** — the V3/V4 hinge ornament. Used at the narrative pivot from "current state / research" to "intervention." There is no narrative yet, therefore no hinge to mark. Add when real prose lands.
+- **ProcessTimeline** — used for explicit phased frameworks (ferguson-cx). The placeholder doesn't describe a phase model. Add only if the composer round names one.
+- **DarkBand** — used when the case has named, photographable artifacts to feature (ferguson-cx prototypes). The case has no artifacts on disk. Skip until at least one artifact exists.
+
+## Specimen choice
+
+**Camellia** (proposed; please confirm or override).
+
+Reason: the V3 design system specimen-symbolism table (`reference/portfoliodesignsystem_04_21_2026v3.pdf`, section 04) wasn't readable from this environment, so I'm reasoning from precedent rather than the canonical table:
+
+- **amaranthus** is taken (agetech / caregiving — duration, weight)
+- **protea** is taken (ferguson-cx / Ferguson — architectural, industrial, B2B distribution)
+- **fig** is taken (carmax / fifty-person design team — interior structure made visible)
+
+For an e-commerce case I proposed camellia because it's a winter cultivar with strong commercial provenance (the tea industry, the Southern US ornamental trade), and its disciplined geometric petal whorl reads as "transactional clarity" without being on-the-nose about retail. It's also visually distinct from the three already-assigned specimens in the live site.
+
+**This is a propose-and-flag, not a confident assignment.** If Whitney has a different specimen in mind, change `specimen` and `specimenSignoff` in the MDX frontmatter and the inline `specimen=` prop on `<SpecimenSignoff />`.
+
+## Image assets referenced (TODO — Whitney to upload)
+
+- `/images/specimen-camellia.jpg` — cover specimen, referenced from frontmatter `specimen` field. **Does not exist on disk.**
+- `/images/signoff-camellia.png` — end-of-case ornament, referenced from frontmatter `specimenSignoff` and the `<SpecimenSignoff specimen=...>` prop. **Does not exist on disk.**
+
+No in-body figures, hero image, screenshots, blueprints, or workshop photography are referenced. The polished draft's `hero_image: "/images/cases/ecomm/hero.jpg"` was dropped from frontmatter because (a) the schema makes hero_image optional, (b) the asset doesn't exist, and (c) the V4 reference cases (agetech, ferguson-cx) on this branch don't set it. If Whitney wants a hero, add the field back when an asset exists.
+
+## Narrative content that didn't fit V4 vocabulary
+
+None. There is no narrative content. Every section is a TODO instruction, and TODO instructions don't need a V4 component — they need an interview and a composer round.
+
+What I removed (not narrative, but worth flagging):
+- The top `{/* PLACEHOLDER DRAFT — ecomm ... */}` MDX comment from the polished draft.
+- The bottom `{/* COMPOSER HANDOFF NOTES ... COPYWRITER NOTES ... */}` MDX comment block from the polished draft.
+
+Both were removed per the agent definition's hard rule: "The MDX file should end cleanly with `<SpecimenSignoff />` ... no trailing comment block." The substance of those upstream notes is preserved in `agent-land/drafts/ecomm.mdx` for the next composer round.
+
+## Open questions for Whitney
+
+1. **Gating:** is this case in or out of the portfolio? The Critic raised a real strategic question about whether the underlying work (per the PDF) is service design or junior IXD support. Until that is resolved, no amount of design-system or copy work will produce a case that argues for itself. If it's out, delete the file. If it's in, run the case-interviewer agent against the PDF before the next composer round.
+2. **Specimen:** confirm or override camellia. See Specimen choice above. The V3 PDF has the canonical assignment table; I couldn't read it from this environment.
+3. **Anonymization:** the title currently reads `TODO: ecomm case title` and the client field reads `TODO: client or industry descriptor`. The PDF in raw material is named `Ecommerce - Case Study.pdf` — does it identify the client by name, and if so, can the client be named publicly? This decision shapes the title formula, the client field, and any verbatim quotes.
+4. **Tags:** the polished draft frontmatter sets `['Service Design', 'E-commerce']`. The Critic flagged these as potentially over-claiming relative to the source material. I preserved them verbatim per the "do not modify the prose" rule, but they may need to change once the case's actual scope is settled.
+5. **Title formula:** V4 titles use the two-clause `<em>`-italicized form ("How do you prototype <em>an AI service?</em>"). The placeholder title is a literal `TODO` string, which is structurally valid for a draft but not V4-shaped. The next composer round should produce a real two-clause title.
+
+## For the next composer round
+
+The most useful single action before another composer pass is to run the case-interviewer agent against the PDF that does exist (`raw-case-material/ecomm/Ecommerce - Case Study.pdf`) to extract: project facts, Whitney's role, anonymization constraints, candidate spine, candidate quotes, candidate metrics. With that interview transcript and a `CASE-CONTEXT.md` in the case folder, the composer has something to draft from. Without it, the next round produces another scaffold.

--- a/src/content/cases/ecomm.mdx
+++ b/src/content/cases/ecomm.mdx
@@ -18,10 +18,25 @@ import StatRow from '../../components/StatRow.astro';
 import PullQuote from '../../components/PullQuote.astro';
 import InsightCallout from '../../components/InsightCallout.astro';
 import SpecimenSignoff from '../../components/SpecimenSignoff.astro';
+import Placeholder from '../../components/Placeholder.astro';
 
 ## The question
 
 TODO: Open the case with the real problem the organization faced, in plainspoken terms a non-designer could grasp. What was the e-commerce client trying to do that it didn't know how to do? What was the tension? Avoid summarizing the brief; name the underlying difficulty.
+
+<Placeholder
+  kind="section"
+  size="block"
+  ask="Gating decision before any further composer work: is this case in or out of the portfolio? If in, what's the frame — early-career artifact, a now-versus-then reflection, or elevated with material the source PDF doesn't contain?"
+  why="Critic flagged: the only source (Ecommerce - Case Study.pdf) describes IXD support inside an established Fjord pattern system circa 2015 — wireframing in Axure, a track-order content adjustment. Sitting next to agetech and ferguson-cx as 'Service Design,' it reads as a category mismatch and quietly subtracts trust from the cases on either side."
+  alternatives={[
+    "Cut the case entirely",
+    "Reframe explicitly as an early-career artifact with a now-versus-then reflection that earns its place by showing how Whitney's thinking has evolved",
+    "Elevate with material the PDF doesn't contain: the business reason for the tablet bet, what Fjord learned about quick-turn briefs, organizational dynamics the writer-as-junior-designer didn't have visibility into at the time",
+    "Rewrite frontmatter tags to honest labels (Interaction Design, Tablet UX, Early Career) if the case stays — current 'Service Design / E-commerce' tags over-claim relative to source"
+  ]}
+  source="critic-flag"
+/>
 
 ## The situation
 
@@ -36,10 +51,35 @@ TODO: The body of the case. Resist a chronological methodology march. Pick a spi
 - A pivot or strategic reframe
 - Evidence of outcomes
 
+<Placeholder
+  kind="section"
+  size="block"
+  ask="A now-versus-then reflection that turns this early-career IXD task into a deliberate note about how Whitney's thinking has evolved — what she'd push back on now, what she'd ask the IXD leads, what business and organizational context she'd want that nobody told her at the time"
+  why="Critic flagged: the source PDF is method narration (reviewed the site, sketched, prototyped in Axure, stress-tested with colleagues, adjusted the track-order screen) with no turn, no surprise, no business tension, no outcome data, and no reflection. Without a spine the next composer round drafts another junior-portfolio entry. Now-versus-then is the only credible spine the source can support."
+  alternatives={[
+    "Cut the case (covered upstream by the gating decision)",
+    "If retained without a now-vs-then frame, drop tags and any framing that implies senior-scope service design"
+  ]}
+  source="critic-flag"
+/>
+
 <InsightCallout label="TODO">
 Use this slot for the case's central design or strategic principle, in Whitney's own
 words wherever possible. Pull from her notes or transcripts. Do not fabricate.
 </InsightCallout>
+
+<Placeholder
+  kind="image"
+  size="in-body-figure"
+  ask="Wireframe or clickable-prototype screenshot lifted from raw-case-material/ecomm/Ecommerce - Case Study.pdf — the Axure prototype of a redesigned site section, or the track-order screen showing the address-import refinement"
+  why="If the case stays, the PDF is the only visual artifact available, and the IXD work needs to be visible in concrete form rather than narrated abstractly. The track-order screen is especially worth pulling because it carries the only specific contribution Whitney names in the source."
+  alternatives={[
+    "Pen-and-paper sketch from the early review/sketch phase if the PDF includes one",
+    "Side-by-side: original site fragment vs. redesigned tablet variant",
+    "Drop in-body figures and let the prose carry — only viable if the spine becomes a now-vs-then reflection where artifacts are intentionally absent"
+  ]}
+  source="visual-director-recommendation"
+/>
 
 ## Evidence
 
@@ -48,6 +88,19 @@ TODO: Pull the strongest participant or stakeholder quote here once transcripts 
 <PullQuote attribution="TODO: source attribution per redaction rules">
 TODO: pull a quote from a real transcript or note. Do not invent.
 </PullQuote>
+
+<Placeholder
+  kind="quote"
+  size="block"
+  ask="One decisive line for the PullQuote. The only candidate the source PDF supplies is Whitney's own contribution: 'I realized it would be helpful to shoppers to be able to import pre-existing addresses already stored in their account information.'"
+  why="Per critic, the PDF carries no participant or stakeholder quotes — Whitney's own IXD insight is the only candidate, and the call is whether that line earns the elevated treatment or reads as junior. The decision likely rides on which spine the case settles into."
+  alternatives={[
+    "Pull a line from Whitney's now-versus-then reflection once it's written — that's where a senior voice would actually live",
+    "Drop the PullQuote entirely; the case doesn't need it if Evidence becomes a now-vs-then reframe",
+    "If the case is reframed as an early-career artifact, surface a candid sentence about what Whitney didn't yet know how to ask for"
+  ]}
+  source="visual-director-recommendation"
+/>
 
 ## The decision / outcome
 
@@ -59,8 +112,41 @@ TODO: What changed because of this work? If the project shipped, what did the da
   { value: 'TODO', label: 'TODO: outcome metric three' },
 ]} />
 
+<Placeholder
+  kind="stat"
+  size="stat-cell"
+  ask="Real values for all three StatRow cells, or a decision to drop the StatRow entirely"
+  why="The source PDF contains no shipped numbers, no engagement metrics, no post-launch data, and no commercial outcome. The case is 10+ years old and the data is unlikely to surface from an interview now. Three TODO cells in the rendered preview will read as a stronger over-claim than the framing tags."
+  alternatives={[
+    "Drop the StatRow entirely — the case can close on qualitative reflection alone",
+    "Replace with three qualitative claims (e.g. what shipped, what stuck in Fjord's pattern system, what Whitney still uses) — but only if those qualitative claims can be sourced",
+    "Replace with three early-career-artifact framings (year, Whitney's level, scope of authored work) if the case is reframed as a now-vs-then piece"
+  ]}
+/>
+
 ## What I'm carrying forward
 
 TODO: Two to four reflections that demonstrate senior taste — what the project taught Whitney about service design, prototyping, working in this industry, or her own practice. The "still thinking about" question often surfaces the case's real intellectual content.
+
+## What I need from you
+
+This section is scaffolding from the visual-director agent. Delete it before publishing. This case is a pre-draft scaffold — every section body is a TODO instruction, not prose. The most load-bearing items below are the two critic-flag sections; nothing else lands until those are resolved.
+
+### Sections to add (per critic) (2)
+
+- **Gating decision** — Is this case in or out of the portfolio? Critic: the source PDF describes IXD support inside an established Fjord pattern system circa 2015, which reads as a category mismatch next to agetech and ferguson-cx and "actively hurts the portfolio" if left as is. Three viable paths: cut, reframe as early-career artifact with a now-vs-then reflection, or elevate with material the PDF doesn't contain (business reason for the tablet bet, organizational dynamics, what Fjord learned about quick-turn briefs). *Where:* upstream of everything — flagged in "The question" but it shapes the whole file. Also touches frontmatter tags (`Service Design`, `E-commerce`), which the critic flagged as over-claiming relative to the source.
+- **Now-versus-then reflection as the spine** — Contingent on keeping the case. Critic: the PDF is method narration with no turn, no surprise, no business tension, no outcome data, no reflection — "the only spine I can see being credible from this material" is a now-vs-then read on early-career craft. *Where:* "What we did" section, replacing the chronological build/test/pivot scaffolding.
+
+### Images (1)
+
+- **In-body figure from the source PDF** — Axure wireframe or clickable-prototype screenshot, ideally the track-order screen with the address-import refinement (the only specific contribution Whitney names). *Where:* "What we did" section, after the InsightCallout. *Source:* `raw-case-material/ecomm/Ecommerce - Case Study.pdf`. *Alternatives:* pen-and-paper sketch if the PDF carries one; side-by-side original-vs-redesigned variant; or drop in-body figures entirely if the spine is a now-vs-then reflection where artifacts are deliberately absent.
+
+### Stat values (1)
+
+- **All three StatRow cells, or a decision to drop the StatRow** — The PDF carries no shipped numbers, no engagement metrics, no commercial outcome. *Where:* "The decision / outcome" section. *Source:* drop the StatRow, or replace with three qualitative claims (what shipped, what stuck in Fjord's pattern system, what Whitney still uses) — but only if those qualitative claims can be sourced from an interview against the PDF.
+
+### Pull quotes (1)
+
+- **One decisive line for the PullQuote in Evidence** — Only candidate in the source is Whitney's own IXD insight ("I realized it would be helpful to shoppers to be able to import pre-existing addresses already stored in their account information"). *Source:* the PDF, page describing the track-order screen refinement. *Alternative:* pull a line from the now-vs-then reflection once it exists — that's where the senior voice actually lives — or drop the PullQuote.
 
 <SpecimenSignoff specimen="/images/signoff-camellia.png" />

--- a/src/content/cases/ecomm.mdx
+++ b/src/content/cases/ecomm.mdx
@@ -1,0 +1,66 @@
+---
+title: 'TODO: ecomm case title'
+client: 'TODO: client or industry descriptor'
+year: 2026
+role: "TODO: Whitney's role on the project"
+team: 'TODO: team composition'
+timeline: 'TODO: project timeline'
+tags:
+  - 'Service Design'
+  - 'E-commerce'
+summary: 'TODO: one sentence for the work grid card. This case is currently a placeholder pending raw material and an interview transcript.'
+specimen: '/images/specimen-camellia.jpg'
+specimenSignoff: '/images/signoff-camellia.png'
+slug: 'ecomm'
+status: 'draft'
+---
+import StatRow from '../../components/StatRow.astro';
+import PullQuote from '../../components/PullQuote.astro';
+import InsightCallout from '../../components/InsightCallout.astro';
+import SpecimenSignoff from '../../components/SpecimenSignoff.astro';
+
+## The question
+
+TODO: Open the case with the real problem the organization faced, in plainspoken terms a non-designer could grasp. What was the e-commerce client trying to do that it didn't know how to do? What was the tension? Avoid summarizing the brief; name the underlying difficulty.
+
+## The situation
+
+TODO: Establish what the service was, who it served, and Whitney's specific role and scope. If she joined mid-project, say when and after what. If she owned a particular set of deliverables (research, blueprint, prototype, etc.), name them with enough specificity that a senior reader can tell what she did versus what the team did.
+
+## What we did
+
+TODO: The body of the case. Resist a chronological methodology march. Pick a spine — most likely a turn, a reframe, or a moment of surprise — and structure around it. Sections might include:
+
+- The build or research phase, with a specific moment that mattered
+- What testing or synthesis revealed
+- A pivot or strategic reframe
+- Evidence of outcomes
+
+<InsightCallout label="TODO">
+Use this slot for the case's central design or strategic principle, in Whitney's own
+words wherever possible. Pull from her notes or transcripts. Do not fabricate.
+</InsightCallout>
+
+## Evidence
+
+TODO: Pull the strongest participant or stakeholder quote here once transcripts exist. A single well-chosen quote beats five mediocre ones.
+
+<PullQuote attribution="TODO: source attribution per redaction rules">
+TODO: pull a quote from a real transcript or note. Do not invent.
+</PullQuote>
+
+## The decision / outcome
+
+TODO: What changed because of this work? If the project shipped, what did the data say? If it didn't ship, what did the organization learn or decide? Numbers where they exist, honest qualitative statements where they don't.
+
+<StatRow stats={[
+  { value: 'TODO', label: 'TODO: outcome metric one' },
+  { value: 'TODO', label: 'TODO: outcome metric two' },
+  { value: 'TODO', label: 'TODO: outcome metric three' },
+]} />
+
+## What I'm carrying forward
+
+TODO: Two to four reflections that demonstrate senior taste — what the project taught Whitney about service design, prototyping, working in this industry, or her own practice. The "still thinking about" question often surfaces the case's real intellectual content.
+
+<SpecimenSignoff specimen="/images/signoff-camellia.png" />


### PR DESCRIPTION
Applies V4 portfolio design system to the polished draft from Agent-Land PR #16 (https://github.com/whitneyesque/Agent-Land/pull/16). Handoff notes (component choices, image-asset TODOs, open questions) are in the HTML comment at the bottom of src/content/cases/ecomm.mdx. To preview locally: cd ~/dev/whitneyesque.github.io && git fetch origin && git checkout design-system/ecomm-16 && npm install && npm run dev — then open http://localhost:4321/cases/ecomm