### PR TITLE
Real research quotes for work-page thumbnails

### DIFF
--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -20,7 +20,7 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
   <section class="section work-intro">
     <span class="section-label">Selected Work</span>
     <h1>A handful of projects. Each one started overgrown. <em>Each one ended with a clearer path through.</em></h1>
-    <p class="section-subtitle">Selected projects from retail, agetech, financial services, and public sector. Full case studies available on request.</p>
+    <p class="section-subtitle">Selected projects from retail, agetech, financial services, and public sector.</p>
   </section>
 
   <section class="section work-list">
@@ -33,8 +33,8 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
         <span class="thumb-cite">Research participant, caregiver intake study</span>
       </div>
       <div class="project-info">
-        <span class="section-label">Featured</span>
-        <h3 class="project-title">Designing a caregiving benefit for the sandwich generation</h3>
+        <span class="section-label">Featured · 2026</span>
+        <h3 class="project-title">Designing a caregiving benefit <em>for the sandwich generation.</em></h3>
         <p class="project-summary">A zero-to-one innovation project inside a large insurance company, building an employer-sponsored benefit for employees caring for aging parents. Led research with working caregivers, developed the service concept and system capabilities, and built a working GPT prototype with eight distinct interaction modes to test the experience before committing to build.</p>
         <div class="tag-row">
           <span class="tag">AgeTech</span>
@@ -54,9 +54,12 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
     <div class="project-grid">
 
       <article class="project-card reveal">
-        <div class="project-thumb"></div>
+        <div class="project-thumb">
+          <p class="thumb-quote">&ldquo;We don&rsquo;t trust our data.&rdquo;</p>
+          <span class="thumb-cite">VP, Business Group</span>
+        </div>
         <div class="project-card-body">
-          <h3>Bringing order to enterprise product data at Ferguson</h3>
+          <h3>Bringing order to enterprise product data <em>at Ferguson.</em></h3>
           <p class="project-summary">Ferguson, the largest distributor in North American construction supply, was managing hundreds of thousands of products through manual spreadsheet workflows that had stopped scaling. Mapped 275+ steps across twelve stakeholder groups, identified redundant workflows between teams, and delivered an evolution map of 290+ capabilities phased across four years. Enough clarity for the team to secure funding and start building.</p>
           <div class="tag-row">
             <span class="tag">Retail</span>
@@ -64,14 +67,17 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
             <span class="tag">Evolution Map</span>
             <span class="tag">Future State Vision</span>
           </div>
-          <span class="project-status">Contact me to view full portfolio</span>
+          <span class="project-card-meta">Case study · 2024</span>
         </div>
       </article>
 
       <article class="project-card reveal">
-        <div class="project-thumb"></div>
+        <div class="project-thumb">
+          <p class="thumb-quote">&ldquo;6 to 8 weeks of waiting &mdash; mostly because of the billing system.&rdquo;</p>
+          <span class="thumb-cite">Dealer, lender ecosystem research</span>
+        </div>
         <div class="project-card-body">
-          <h3>From manual workaround to scalable service at Allied Solutions</h3>
+          <h3>From manual workaround <em>to scalable service at Allied Solutions.</em></h3>
           <p class="project-summary">A successful pilot had outgrown the manual processes holding it together, right as new federal regulations made the service mandatory for lenders nationwide. Ran research across a multi-actor ecosystem of lenders, dealers, and third-party providers, located the real bottleneck (not where anyone expected), and co-created a service blueprint and capability map the client used to build an internal service design practice alongside the product.</p>
           <div class="tag-row">
             <span class="tag">Financial Services</span>
@@ -79,21 +85,24 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
             <span class="tag">Service Blueprint</span>
             <span class="tag">Capabilities Map</span>
           </div>
-          <span class="project-status">Contact me to view full portfolio</span>
+          <span class="project-card-meta">Case study · 2023</span>
         </div>
       </article>
 
       <article class="project-card reveal">
-        <div class="project-thumb"></div>
+        <div class="project-thumb">
+          <p class="thumb-quote">&ldquo;Things have changed so dramatically since the pandemic. You can feel it at every branch.&rdquo;</p>
+          <span class="thumb-cite">Branch staff, ambassador series</span>
+        </div>
         <div class="project-card-body">
-          <h3>A strategic plan for the San Francisco Public Library</h3>
+          <h3>A strategic plan <em>for the San Francisco Public Library.</em></h3>
           <p class="project-summary">Part of a consulting team (alongside Gensler and Margaret Sullivan Studio) helping SFPL set direction for the next five years while preserving the culture that makes the library work. Ran co-creation with thirty-two staff ambassadors across departments to close the gap between leadership vision and frontline reality. The Library Commission adopted the plan unanimously.</p>
           <div class="tag-row">
             <span class="tag">Public Sector</span>
             <span class="tag">Workshop Design</span>
             <span class="tag">Facilitation</span>
           </div>
-          <span class="project-status">Contact me to view full portfolio</span>
+          <span class="project-card-meta">Case study · 2022</span>
         </div>
       </article>
 
@@ -102,7 +111,7 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
           <span class="coming-soon">Coming soon</span>
         </div>
         <div class="project-card-body">
-          <h3>More work on the way</h3>
+          <h3>More work <em>on the way.</em></h3>
           <p class="project-summary">Additional case studies are in progress.</p>
         </div>
       </article>


### PR DESCRIPTION
Swaps the three lorem-ipsum thumbnail placeholders (Ferguson, Allied, SFPL) for real research-attributed quotes pulled from Miro. Also pulls in copy improvements that were sitting in the working tree (em-dash titles, year meta on cards). Cite copy follows the agetech precedent shape: `role, study`. Open if you want to tweak any of the cite phrases.