### PR TITLE
Fix preview URL: include .html so PR-bot link works

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -46,7 +46,7 @@ jobs:
           script: |
             const url = '${{ steps.deploy.outputs.url }}';
             const slug = '${{ steps.slug.outputs.slug }}';
-            const caseUrl = slug ? `${url}/cases/${slug}` : url;
+            const caseUrl = slug ? `${url}/cases/${slug}.html` : url;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
Tiny fix. The PR-preview bot was generating /cases/<slug> URLs without the .html extension, but Astro's build.format: 'file' config produces .html files. Result: clicking the bot's 'Direct link' returned 404. Now includes .html.