### PR TITLE
Link live case pages from work page; add ailx + ferguson-cx cards

### DIFF
--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -68,6 +68,7 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
             <span class="tag">Future State Vision</span>
           </div>
           <span class="project-card-meta">Case study · 2024</span>
+          {published.has('ferguson-data') && <a href="/cases/ferguson-data.html" class="btn">Read Case Study</a>}
         </div>
       </article>
 
@@ -86,6 +87,7 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
             <span class="tag">Capabilities Map</span>
           </div>
           <span class="project-card-meta">Case study · 2023</span>
+          {published.has('allied') && <a href="/cases/allied.html" class="btn">Read Case Study</a>}
         </div>
       </article>
 
@@ -103,6 +105,45 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
             <span class="tag">Facilitation</span>
           </div>
           <span class="project-card-meta">Case study · 2022</span>
+          {published.has('sfpl') && <a href="/cases/sfpl.html" class="btn">Read Case Study</a>}
+        </div>
+      </article>
+
+      <article class="project-card reveal">
+        <div class="project-thumb">
+          <p class="thumb-quote">&ldquo;AI in service of value &mdash; versus everyone in service of AI.&rdquo;</p>
+          <span class="thumb-cite">Patrick Quattlebaum, engagement lead</span>
+        </div>
+        <div class="project-card-body">
+          <h3>From &ldquo;we should do AI&rdquo; <em>to a working vocabulary for AI in services.</em></h3>
+          <p class="project-summary">A two-day workshop with a national automotive retailer's fifty-person design team. Co-facilitated with Patrick Quattlebaum (Harmonic Design); authored the Four Dimensions of AI in Services framework. The workshop produced a vocabulary, a canvas, and a control taxonomy for treating AI as a design material rather than a hammer in search of a nail.</p>
+          <div class="tag-row">
+            <span class="tag">Service Design</span>
+            <span class="tag">AI</span>
+            <span class="tag">Workshop Facilitation</span>
+            <span class="tag">Framework Design</span>
+          </div>
+          <span class="project-card-meta">Case study · 2025</span>
+          {published.has('ailx') && <a href="/cases/ailx.html" class="btn">Read Case Study</a>}
+        </div>
+      </article>
+
+      <article class="project-card reveal">
+        <div class="project-thumb">
+          <p class="thumb-quote">&ldquo;Order not ready. Associate not present.&rdquo;</p>
+          <span class="thumb-cite">The two wait-time scenarios</span>
+        </div>
+        <div class="project-card-body">
+          <h3>From &ldquo;make waiting feel better&rdquo; <em>to two prototypes in two real Ferguson branches.</em></h3>
+          <p class="project-summary">A vague brief about &ldquo;the perception of waiting&rdquo; reframed into two specific service breakdowns &mdash; Order Not Ready and Associate Not Present &mdash; then resolved with two named prototypes (Make-It-Happen and KnockKnock) deployed live in branches and tested with real customers. Both met every design criterion.</p>
+          <div class="tag-row">
+            <span class="tag">Service Design</span>
+            <span class="tag">Prototyping</span>
+            <span class="tag">Live Field Testing</span>
+            <span class="tag">Workshop Facilitation</span>
+          </div>
+          <span class="project-card-meta">Case study · 2022</span>
+          {published.has('ferguson-cx') && <a href="/cases/ferguson-cx.html" class="btn">Read Case Study</a>}
         </div>
       </article>
 


### PR DESCRIPTION
Two changes:

1. **Read Case Study links on existing cards.** Ferguson Data, Allied, and SFPL each get a conditional Read Case Study button, gated on `published.has(slug)` — so the link auto-renders the moment the case file lands on main. Same pattern as agetech's featured card.

2. **New cards for ailx and ferguson-cx.** Both case pages are already live on main but had no work-page presence. Adds them to the grid before the More-on-the-way placeholder, with locked thumbnail quotes from research.

After merge, every case on main will be linked from /work, and Ferguson Data's link will activate automatically once its design-system PR merges.