### PR TITLE
Ignore .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist/
 .env
 .env.*
 !.env.example
+
+# Claude Code local-only tooling (launch configs, worktrees, session state)
+.claude/


### PR DESCRIPTION
Adds .claude/ to .gitignore so Claude Code local tooling (launch configs, worktrees, session state) doesn't show up as pending changes in GitHub Desktop and can't accidentally land in PRs.