### PR TITLE
Publish ferguson-data case

### DIFF
--- a/src/content/cases/ferguson-data.mdx
+++ b/src/content/cases/ferguson-data.mdx
@@ -15,7 +15,7 @@ summary: 'Reframed an overwhelmed product-data team''s tooling problem as a serv
 specimen: '/images/specimen-cymbidium.jpg'
 specimenSignoff: '/images/signoff-cymbidium.png'
 slug: 'ferguson-data'
-status: 'draft'
+status: 'published'
 ---
 import StatRow from '../../components/StatRow.astro';
 import PullQuote from '../../components/PullQuote.astro';


### PR DESCRIPTION
Flips ferguson-data status from 'draft' to 'published'. After merge, /cases/ferguson-data.html will render and the Read Case Study button will appear on the work page card.