### PR TITLE
Polish: clickable cards, prev/next nav, mobile fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "whitneyesque-site",
       "version": "0.1.0",
       "dependencies": {
-        "@astrojs/cloudflare": "^12.6.13"
+        "@astrojs/cloudflare": "12"
       },
       "devDependencies": {
         "@astrojs/mdx": "^4.0.0",

--- a/public/style.css
+++ b/public/style.css
@@ -291,11 +291,19 @@ p + p { margin-top: var(--sp-2); }
 .work-list { padding-top: 0; }
 
 .project-featured {
+  position: relative;
   display: grid; grid-template-columns: 1.2fr 1fr; gap: var(--sp-8);
   padding: var(--sp-8);
   background: var(--cream);
   border-radius: 8px;
   margin-bottom: var(--sp-6);
+  transition: box-shadow .25s ease, transform .25s ease;
+}
+.project-featured.has-link { cursor: pointer; }
+.project-featured.has-link:hover,
+.project-featured.has-link:focus-within {
+  box-shadow: 0 18px 40px -20px rgba(42, 37, 32, .35), 0 4px 12px -4px rgba(42, 37, 32, .15);
+  transform: translateY(-2px);
 }
 .project-featured .project-thumb {
   aspect-ratio: 16 / 10;
@@ -322,11 +330,36 @@ p + p { margin-top: var(--sp-2); }
 
 .project-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-5); }
 .project-card {
+  position: relative;
   background: var(--cream);
   border-radius: 8px;
   overflow: hidden;
   display: flex; flex-direction: column;
+  transition: box-shadow .25s ease, transform .25s ease;
 }
+.project-card.has-link { cursor: pointer; }
+.project-card.has-link:hover,
+.project-card.has-link:focus-within {
+  box-shadow: 0 18px 40px -20px rgba(42, 37, 32, .35), 0 4px 12px -4px rgba(42, 37, 32, .15);
+  transform: translateY(-2px);
+}
+.project-card.placeholder { cursor: default; }
+.project-card.placeholder:hover { box-shadow: none; transform: none; }
+
+/* Stretched-link: the h3 <a> covers the entire card. */
+.project-card-link {
+  color: inherit;
+  text-decoration: none;
+}
+.project-card-link::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+/* Keep explicit btn on top of the stretched link */
+.project-featured .btn,
+.project-card .btn { position: relative; z-index: 2; }
 .project-card .project-thumb {
   aspect-ratio: 16 / 10;
   background: var(--charcoal);
@@ -352,9 +385,8 @@ p + p { margin-top: var(--sp-2); }
 }
 .project-card .project-summary { font-size: 14px; color: var(--charcoal-mid); line-height: 1.6; }
 
-/* Card meta line: "CASE STUDY · 2024" or contact note */
-.project-status,
-.project-card-meta {
+/* "Contact me to view full portfolio" — only used on the featured card now. */
+.project-status {
   display: inline-block;
   margin-top: var(--sp-3);
   font-family: var(--font-mono);
@@ -716,6 +748,27 @@ p + p { margin-top: var(--sp-2); }
   .project-featured { grid-template-columns: 1fr; padding: var(--sp-4); }
   .project-grid { grid-template-columns: 1fr; }
 
+  /* Tag row: breathing room above the Read Case Study button on mobile */
+  .project-featured .tag-row { margin-bottom: var(--sp-3); }
+
+  /* Cap thumb height so the dark area doesn't dominate full-width cards */
+  .project-card .project-thumb,
+  .project-featured .project-thumb {
+    aspect-ratio: auto;
+    min-height: 180px;
+    max-height: 240px;
+  }
+
+  /* About timeline: stack date above content so it doesn't eat half the viewport */
+  .wm-timeline-entry {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+  .wm-date-tag { padding-top: 0; }
+
+  /* Kill extra bottom padding on work list — footer brings its own top padding */
+  .work-list { padding-bottom: 0; }
+
   .site-footer { padding: var(--sp-8) var(--sp-3); }
   .site-footer .footer-content { flex-direction: column; gap: var(--sp-4); }
 
@@ -957,21 +1010,58 @@ p + p { margin-top: var(--sp-2); }
   color: var(--charcoal-soft);
 }
 
-/* Case footer */
-.case-footer {
-  max-width: 800px; margin: 0 auto;
-  padding: 0 var(--sp-8) var(--sp-16);
+/* Case nav — prev / All work / next */
+.case-nav {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: var(--sp-8) var(--sp-8) var(--sp-16);
   border-top: 1px solid var(--cream-deep);
-  padding-top: var(--sp-6);
 }
-.case-back-bottom {
-  font-family: var(--font-mono);
-  font-size: 11px; letter-spacing: .12em; text-transform: uppercase;
-  color: var(--gold-text);
+.case-nav-inner {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--sp-6);
+  align-items: start;
+}
+.case-nav-link {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
   text-decoration: none;
+  color: var(--charcoal);
   transition: color .2s;
 }
-.case-back-bottom:hover { color: var(--rust); }
+.case-nav-link:hover { color: var(--gold-text); }
+.case-nav-prev { text-align: left; }
+.case-nav-next { text-align: right; }
+.case-nav-direction {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--gold-text);
+}
+.case-nav-title {
+  font-family: var(--font-display);
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: inherit;
+}
+.case-nav-title em { color: var(--gold-text); font-style: italic; }
+.case-nav-allwork {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--charcoal-soft);
+  text-decoration: none;
+  align-self: center;
+  white-space: nowrap;
+  transition: color .2s;
+}
+.case-nav-allwork:hover { color: var(--rust); }
+.case-nav-spacer { display: block; }
 
 /* Case responsive */
 @media (max-width: 768px) {
@@ -981,7 +1071,17 @@ p + p { margin-top: var(--sp-2); }
   .case-body { padding: var(--sp-8) var(--sp-3); }
   .pull-quote { margin-left: 0; margin-right: 0; }
   .stat-row { gap: var(--sp-4); }
-  .case-footer { padding: var(--sp-5) var(--sp-3) var(--sp-12); }
+  .case-nav { padding: var(--sp-6) var(--sp-3) var(--sp-12); }
+  .case-nav-inner {
+    grid-template-columns: 1fr;
+    gap: var(--sp-5);
+  }
+  .case-nav-prev,
+  .case-nav-next { text-align: left; }
+  .case-nav-allwork {
+    align-self: start;
+    order: 99;
+  }
 }
 
 /* ----- ACCESSIBILITY ----- */

--- a/src/content/cases/ferguson-data.mdx
+++ b/src/content/cases/ferguson-data.mdx
@@ -12,8 +12,6 @@ tags:
   - 'Cross-functional Alignment'
   - 'Roadmapping'
 summary: 'Reframed an overwhelmed product-data team''s tooling problem as a service problem, mapped 275 steps across twelve roles, and produced a four-year roadmap that funded itself.'
-specimen: '/images/specimen-cymbidium.jpg'
-specimenSignoff: '/images/signoff-cymbidium.png'
 slug: 'ferguson-data'
 status: 'published'
 ---
@@ -21,7 +19,6 @@ import StatRow from '../../components/StatRow.astro';
 import PullQuote from '../../components/PullQuote.astro';
 import InsightCallout from '../../components/InsightCallout.astro';
 import BotanicalDivider from '../../components/BotanicalDivider.astro';
-import SpecimenSignoff from '../../components/SpecimenSignoff.astro';
 import Placeholder from '../../components/Placeholder.astro';
 
 <StatRow stats={[
@@ -117,5 +114,3 @@ Open content questions still owed (carried forward from composer / critic / desi
 - One scene from the work — a workshop disagreement, a moment the map on the wall changed someone's mind, a vendor or sales-rep observation that re-pointed the engagement. Without one, the case stays methodology-as-march. A scene also unlocks a second pull quote from a named source, which both PullQuote blocks currently lack.
 - Any business-side magnitude the critic flagged: program size, FTE equivalent of the manual workflow, time-to-list reduction, projected cost-out from merging the two redundant workflows. Even one number, NDA-anonymized, lifts the outcome out of consultancy boilerplate.
 - Confidentiality confirmation: Ferguson name, vendor counts, product counts, capability counts at the level of specificity used here.
-
-<SpecimenSignoff specimen="/images/signoff-cymbidium.png" />

--- a/src/layouts/CaseLayout.astro
+++ b/src/layouts/CaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from './BaseLayout.astro';
+import { getCollection } from 'astro:content';
 
 interface Props {
   title: string;
@@ -25,6 +26,14 @@ const {
 
 const canonicalURL = `https://whitneyesque.github.io/cases/${slug}.html`;
 const pageTitle = `${title} — Whitney Masulis`;
+
+const allPublished = await getCollection('cases', entry => entry.data.status === 'published');
+const ordered = allPublished
+  .map(entry => ({ slug: entry.slug, title: entry.data.title, year: entry.data.year }))
+  .sort((a, b) => b.year - a.year || a.slug.localeCompare(b.slug));
+const currentIndex = ordered.findIndex(c => c.slug === slug);
+const prev = currentIndex > 0 ? ordered[currentIndex - 1] : null;
+const next = currentIndex >= 0 && currentIndex < ordered.length - 1 ? ordered[currentIndex + 1] : null;
 ---
 <BaseLayout
   title={pageTitle}
@@ -68,9 +77,25 @@ const pageTitle = `${title} — Whitney Masulis`;
       <slot />
     </div>
 
-    <footer class="case-footer">
-      <a href="/work.html" class="case-back-bottom">← Back to Work</a>
-    </footer>
+    <nav class="case-nav" aria-label="Case study navigation">
+      <div class="case-nav-inner">
+        {prev ? (
+          <a href={`/cases/${prev.slug}.html`} class="case-nav-link case-nav-prev" rel="prev">
+            <span class="case-nav-direction">← Previous case</span>
+            <span class="case-nav-title" set:html={prev.title} />
+          </a>
+        ) : <span class="case-nav-spacer" aria-hidden="true"></span>}
+
+        <a href="/work.html" class="case-nav-allwork">All work</a>
+
+        {next ? (
+          <a href={`/cases/${next.slug}.html`} class="case-nav-link case-nav-next" rel="next">
+            <span class="case-nav-direction">Next case →</span>
+            <span class="case-nav-title" set:html={next.title} />
+          </a>
+        ) : <span class="case-nav-spacer" aria-hidden="true"></span>}
+      </div>
+    </nav>
 
   </article>
 </BaseLayout>

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -27,14 +27,19 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
 
     <h2 class="sr-only">Featured case study</h2>
 
-    <article class="project-featured reveal">
+    <article class={`project-featured reveal${published.has('agetech') ? ' has-link' : ''}`}>
       <div class="project-thumb">
         <p class="thumb-quote">&ldquo;I just gave you all that information. What did I get for it?&rdquo;</p>
         <span class="thumb-cite">Research participant, caregiver intake study</span>
       </div>
       <div class="project-info">
         <span class="section-label">Featured · 2026</span>
-        <h3 class="project-title">Designing a caregiving benefit <em>for the sandwich generation.</em></h3>
+        <h3 class="project-title">
+          {published.has('agetech')
+            ? <a href="/cases/agetech.html" class="project-card-link">Designing a caregiving benefit <em>for the sandwich generation.</em></a>
+            : <Fragment>Designing a caregiving benefit <em>for the sandwich generation.</em></Fragment>
+          }
+        </h3>
         <p class="project-summary">A zero-to-one innovation project inside a large insurance company, building an employer-sponsored benefit for employees caring for aging parents. Led research with working caregivers, developed the service concept and system capabilities, and built a working GPT prototype with eight distinct interaction modes to test the experience before committing to build.</p>
         <div class="tag-row">
           <span class="tag">AgeTech</span>
@@ -53,13 +58,18 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
 
     <div class="project-grid">
 
-      <article class="project-card reveal">
+      <article class={`project-card reveal${published.has('allied') ? ' has-link' : ''}`}>
         <div class="project-thumb">
           <p class="thumb-quote">&ldquo;6 to 8 weeks of waiting &mdash; mostly because of the billing system.&rdquo;</p>
           <span class="thumb-cite">Dealer, lender ecosystem research</span>
         </div>
         <div class="project-card-body">
-          <h3>From manual workaround <em>to scalable service at Allied Solutions.</em></h3>
+          <h3>
+            {published.has('allied')
+              ? <a href="/cases/allied.html" class="project-card-link">From manual workaround <em>to scalable service at Allied Solutions.</em></a>
+              : <Fragment>From manual workaround <em>to scalable service at Allied Solutions.</em></Fragment>
+            }
+          </h3>
           <p class="project-summary">A successful pilot had outgrown the manual processes holding it together, right as new federal regulations made the service mandatory for lenders nationwide. Ran research across a multi-actor ecosystem of lenders, dealers, and third-party providers, located the real bottleneck (not where anyone expected), and co-created a service blueprint and capability map the client used to build an internal service design practice alongside the product.</p>
           <div class="tag-row">
             <span class="tag">Financial Services</span>
@@ -67,36 +77,44 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
             <span class="tag">Service Blueprint</span>
             <span class="tag">Capabilities Map</span>
           </div>
-          <span class="project-card-meta">Case study · 2023</span>
           {published.has('allied') && <a href="/cases/allied.html" class="btn">Read Case Study</a>}
         </div>
       </article>
 
-      <article class="project-card reveal">
+      <article class={`project-card reveal${published.has('sfpl') ? ' has-link' : ''}`}>
         <div class="project-thumb">
           <p class="thumb-quote">&ldquo;Things have changed so dramatically since the pandemic. You can feel it at every branch.&rdquo;</p>
           <span class="thumb-cite">Branch staff, ambassador series</span>
         </div>
         <div class="project-card-body">
-          <h3>A strategic plan <em>for the San Francisco Public Library.</em></h3>
+          <h3>
+            {published.has('sfpl')
+              ? <a href="/cases/sfpl.html" class="project-card-link">A strategic plan <em>for the San Francisco Public Library.</em></a>
+              : <Fragment>A strategic plan <em>for the San Francisco Public Library.</em></Fragment>
+            }
+          </h3>
           <p class="project-summary">Part of a consulting team (alongside Gensler and Margaret Sullivan Studio) helping SFPL set direction for the next five years while preserving the culture that makes the library work. Ran co-creation with thirty-two staff ambassadors across departments to close the gap between leadership vision and frontline reality. The Library Commission adopted the plan unanimously.</p>
           <div class="tag-row">
             <span class="tag">Public Sector</span>
             <span class="tag">Workshop Design</span>
             <span class="tag">Facilitation</span>
           </div>
-          <span class="project-card-meta">Case study · 2022</span>
           {published.has('sfpl') && <a href="/cases/sfpl.html" class="btn">Read Case Study</a>}
         </div>
       </article>
 
-      <article class="project-card reveal">
+      <article class={`project-card reveal${published.has('ailx') ? ' has-link' : ''}`}>
         <div class="project-thumb">
           <p class="thumb-quote">&ldquo;AI in service of value &mdash; versus everyone in service of AI.&rdquo;</p>
           <span class="thumb-cite">Patrick Quattlebaum, engagement lead</span>
         </div>
         <div class="project-card-body">
-          <h3>From &ldquo;we should do AI&rdquo; <em>to a working vocabulary for AI in services.</em></h3>
+          <h3>
+            {published.has('ailx')
+              ? <a href="/cases/ailx.html" class="project-card-link">From &ldquo;we should do AI&rdquo; <em>to a working vocabulary for AI in services.</em></a>
+              : <Fragment>From &ldquo;we should do AI&rdquo; <em>to a working vocabulary for AI in services.</em></Fragment>
+            }
+          </h3>
           <p class="project-summary">A two-day workshop with a national automotive retailer's fifty-person design team. Co-facilitated with Patrick Quattlebaum (Harmonic Design); authored the Four Dimensions of AI in Services framework. The workshop produced a vocabulary, a canvas, and a control taxonomy for treating AI as a design material rather than a hammer in search of a nail.</p>
           <div class="tag-row">
             <span class="tag">Service Design</span>
@@ -104,18 +122,22 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
             <span class="tag">Workshop Facilitation</span>
             <span class="tag">Framework Design</span>
           </div>
-          <span class="project-card-meta">Case study · 2025</span>
           {published.has('ailx') && <a href="/cases/ailx.html" class="btn">Read Case Study</a>}
         </div>
       </article>
 
-      <article class="project-card reveal">
+      <article class={`project-card reveal${published.has('ferguson-cx') ? ' has-link' : ''}`}>
         <div class="project-thumb">
           <p class="thumb-quote">&ldquo;Order not ready. Associate not present.&rdquo;</p>
           <span class="thumb-cite">The two wait-time scenarios</span>
         </div>
         <div class="project-card-body">
-          <h3>From &ldquo;make waiting feel better&rdquo; <em>to two prototypes in two real Ferguson branches.</em></h3>
+          <h3>
+            {published.has('ferguson-cx')
+              ? <a href="/cases/ferguson-cx.html" class="project-card-link">From &ldquo;make waiting feel better&rdquo; <em>to two prototypes in two real Ferguson branches.</em></a>
+              : <Fragment>From &ldquo;make waiting feel better&rdquo; <em>to two prototypes in two real Ferguson branches.</em></Fragment>
+            }
+          </h3>
           <p class="project-summary">A vague brief about &ldquo;the perception of waiting&rdquo; reframed into two specific service breakdowns &mdash; Order Not Ready and Associate Not Present &mdash; then resolved with two named prototypes (Make-It-Happen and KnockKnock) deployed live in branches and tested with real customers. Both met every design criterion.</p>
           <div class="tag-row">
             <span class="tag">Service Design</span>
@@ -123,7 +145,6 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
             <span class="tag">Live Field Testing</span>
             <span class="tag">Workshop Facilitation</span>
           </div>
-          <span class="project-card-meta">Case study · 2022</span>
           {published.has('ferguson-cx') && <a href="/cases/ferguson-cx.html" class="btn">Read Case Study</a>}
         </div>
       </article>


### PR DESCRIPTION
## Summary

- **Fully-clickable work cards** — stretched-link pattern so clicking anywhere on a card navigates to the case. The explicit "Read Case Study" button stays on `z-index: 2` and remains independently clickable. Hover adds a lift + shadow on cards that have a live link; the placeholder card is excluded.
- **Prev/Next case navigation** — replaces the plain "← Back to Work" link at the bottom of every case page. Walks the published collection sorted by year, shows the adjacent case title (with inline `<em>` support) and direction label. Three-column layout: prev | All work | next.
- **CASE STUDY · YEAR meta line removed** — those labels on the grid cards didn't add value next to the tags.
- **Mobile fixes** — tag-row breathing room before the Read Case Study button; thumb height capped at 240px; about-page timeline date stacks above content; work-list bottom padding removed so footer sits flush.
- **Bonus fix** — `ferguson-data.mdx` was importing the deleted `SpecimenSignoff` component (pre-existing build error from PR #28); stripped the import, usage, and stale frontmatter fields.

## Test plan

- [ ] Work page: hover a card with a live case — shadow + lift appears
- [ ] Work page: click anywhere on the card body — navigates to case
- [ ] Work page: "Read Case Study" button still works independently
- [ ] Case page footer: shows prev / All work / next (or spacer if at ends of list)
- [ ] Case page: no YEAR · CASE STUDY label visible anywhere
- [ ] Mobile (≤768px): tag row has gap above button; thumbs don't dominate; work page footer sits flush
- [ ] Build: `npm run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)