### PR TITLE
Fix: root-relative nav hrefs + rename ailx → ai-lx

### DIFF
--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -8,14 +8,14 @@ const { active, transparent = false } = Astro.props;
 const headerClass = transparent ? 'site-header header-transparent' : 'site-header';
 ---
 <header class={headerClass}>
-  <a href="index.html" class="wordmark">Whitney Masulis</a>
+  <a href="/index.html" class="wordmark">Whitney Masulis</a>
   <button class="nav-toggle" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="primary-nav">
     <span></span><span></span>
   </button>
   <nav id="primary-nav" aria-label="Main navigation">
-    <a href="index.html" class={active === 'home' ? 'active' : undefined} aria-current={active === 'home' ? 'page' : undefined}>Home</a>
-    <a href="work.html" class={active === 'work' ? 'active' : undefined} aria-current={active === 'work' ? 'page' : undefined}>Work</a>
-    <a href="about.html" class={active === 'about' ? 'active' : undefined} aria-current={active === 'about' ? 'page' : undefined}>About</a>
-    <a href="contact.html" class={active === 'contact' ? 'active' : undefined} aria-current={active === 'contact' ? 'page' : undefined}>Contact</a>
+    <a href="/index.html" class={active === 'home' ? 'active' : undefined} aria-current={active === 'home' ? 'page' : undefined}>Home</a>
+    <a href="/work.html" class={active === 'work' ? 'active' : undefined} aria-current={active === 'work' ? 'page' : undefined}>Work</a>
+    <a href="/about.html" class={active === 'about' ? 'active' : undefined} aria-current={active === 'about' ? 'page' : undefined}>About</a>
+    <a href="/contact.html" class={active === 'contact' ? 'active' : undefined} aria-current={active === 'contact' ? 'page' : undefined}>Contact</a>
   </nav>
 </header>

--- a/src/content/cases/ai-lx.mdx
+++ b/src/content/cases/ai-lx.mdx
@@ -12,7 +12,7 @@ tags:
   - 'Framework Design'
   - 'Practice Building'
 summary: 'A two-day workshop that gave a 50-person design team a vocabulary, a canvas, and a control taxonomy for treating AI as a design material, not a hammer.'
-slug: 'ailx'
+slug: 'ai-lx'
 status: 'published'
 ---
 import StatRow from '../../components/StatRow.astro';

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -103,15 +103,15 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
         </div>
       </article>
 
-      <article class={`project-card reveal${published.has('ailx') ? ' has-link' : ''}`}>
+      <article class={`project-card reveal${published.has('ai-lx') ? ' has-link' : ''}`}>
         <div class="project-thumb">
           <p class="thumb-quote">&ldquo;AI in service of value &mdash; versus everyone in service of AI.&rdquo;</p>
           <span class="thumb-cite">Patrick Quattlebaum, engagement lead</span>
         </div>
         <div class="project-card-body">
           <h3>
-            {published.has('ailx')
-              ? <a href="/cases/ailx.html" class="project-card-link">From &ldquo;we should do AI&rdquo; <em>to a working vocabulary for AI in services.</em></a>
+            {published.has('ai-lx')
+              ? <a href="/cases/ai-lx.html" class="project-card-link">From &ldquo;we should do AI&rdquo; <em>to a working vocabulary for AI in services.</em></a>
               : <Fragment>From &ldquo;we should do AI&rdquo; <em>to a working vocabulary for AI in services.</em></Fragment>
             }
           </h3>
@@ -122,7 +122,7 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
             <span class="tag">Workshop Facilitation</span>
             <span class="tag">Framework Design</span>
           </div>
-          {published.has('ailx') && <a href="/cases/ailx.html" class="btn">Read Case Study</a>}
+          {published.has('ai-lx') && <a href="/cases/ai-lx.html" class="btn">Read Case Study</a>}
         </div>
       </article>
 


### PR DESCRIPTION
Two fixes that landed after PR #37 merged:

- **Nav 404s**: SiteHeader hrefs were relative (`work.html`) and resolved to `/cases/work.html` from case pages. Changed to root-relative (`/work.html`).
- **Slug rename**: `ailx` → `ai-lx` (filename, frontmatter, work.astro links).