### PR TITLE
Sticky footer: belt-and-suspenders height approach

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -50,8 +50,7 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  min-height: 100svh;
-  min-height: var(--vh, 100svh); /* --vh set in JS to exact px after iOS computes real viewport */
+  min-height: 100dvh; /* dynamic viewport height — adapts as mobile browser chrome shows/hides */
 }
 
 

--- a/public/style.css
+++ b/public/style.css
@@ -37,7 +37,7 @@
 /* ----- RESET ----- */
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 
-html { color-scheme: light; }
+html { color-scheme: light; height: 100%; }
 
 body {
   font-family: var(--font-body);
@@ -46,11 +46,13 @@ body {
   font-size: 16px;
   line-height: 1.7;
   -webkit-font-smoothing: antialiased;
-  /* Sticky footer: body is a flex column, main grows, footer settles at the end. */
+  /* Sticky footer: body is a flex column, main grows, footer settles at the end.
+     min-height cascade: 100% (most compat) → 100vh → 100dvh (best on modern mobile) */
   display: flex;
   flex-direction: column;
+  min-height: 100%;
   min-height: 100vh;
-  min-height: 100dvh; /* dynamic viewport height — adapts as mobile browser chrome shows/hides */
+  min-height: 100dvh;
 }
 
 


### PR DESCRIPTION
Adds `html { height: 100% }` + `body { min-height: 100% }` as the most universally compatible fallback for the sticky footer pattern. `100dvh` stays as the modern mobile override.

Fixes footer floating above bottom of viewport on phones where viewport unit support is inconsistent.