### PR TITLE
Work card fixes: remove quotes, always show CTA, fix paradise

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -438,11 +438,16 @@ p + p { margin-top: var(--sp-2); }
   opacity: .9;
   pointer-events: none;
 }
-/* White-background specimens (design-system PNGs) need multiply so the white
-   becomes transparent against the dark thumb */
+/* White-background specimens (design-system PNGs) — switch the thumb to cream
+   and use multiply so the white background dissolves; flower colors stay visible.
+   (Multiply on charcoal turns colored flowers nearly black; cream lets them show.) */
+.project-card--alt .project-thumb--light,
+.project-featured--alt .project-thumb--light {
+  background: var(--cream);
+}
 .project-thumb-specimen--light {
   mix-blend-mode: multiply;
-  opacity: .85;
+  opacity: 1;
 }
 
 /* Quote block in the card body (replaces summary paragraph) */

--- a/src/components/WorkCardAlt.astro
+++ b/src/components/WorkCardAlt.astro
@@ -1,33 +1,25 @@
 ---
 /**
  * WorkCardAlt.astro — specimen-forward grid card.
- * Layout: botanical specimen fills the dark thumb; research quote moves to
- * the cream body where summary text used to live. No body copy.
- *
- * specimen: path to an image already on a dark background → mix-blend-mode: lighten
- *           (rose, ranunculus, protea all qualify).
- *           White-background design-system specimens need the CSS class
- *           project-thumb--light-specimen on the thumb instead — handle
- *           by adding a `specimenLight` prop if needed later.
+ * Layout: botanical specimen fills the thumb; title + tags + CTA in body.
+ * Entire card is clickable via the stretched-link pattern (project-card-link::before).
  */
 interface Props {
   title: string;       // may contain HTML (e.g. <em> for gold italic clause)
   href: string;
   specimen?: string;   // optional — falls back to plain dark thumb
-  /** true for white-background specimens (design-system PNGs) → multiply blend;
-   *  false/omitted for dark-background specimens (JPGs) → lighten blend */
+  /** true for white-background specimens (design-system PNGs) → cream thumb +
+   *  multiply blend so the white background dissolves; orange/colored flowers
+   *  show as muted-but-visible rather than nearly-black silhouettes. */
   specimenLight?: boolean;
-  quote: string;       // research quote text, no surrounding curly quotes
-  cite: string;        // attribution line
   tags: string[];
-  published: boolean;
 }
 
-const { title, href, specimen, specimenLight = false, quote, cite, tags, published } = Astro.props;
+const { title, href, specimen, specimenLight = false, tags } = Astro.props;
 ---
 
-<article class={`project-card project-card--alt reveal${published ? ' has-link' : ''}`}>
-  <div class="project-thumb">
+<article class="project-card project-card--alt reveal has-link">
+  <div class={`project-thumb${specimenLight ? ' project-thumb--light' : ''}`}>
     {specimen && (
       <img
         class={`project-thumb-specimen${specimenLight ? ' project-thumb-specimen--light' : ''}`}
@@ -41,18 +33,11 @@ const { title, href, specimen, specimenLight = false, quote, cite, tags, publish
   </div>
   <div class="project-card-body">
     <h3>
-      {published
-        ? <a href={href} class="project-card-link"><Fragment set:html={title} /></a>
-        : <Fragment set:html={title} />
-      }
+      <a href={href} class="project-card-link"><Fragment set:html={title} /></a>
     </h3>
-    <blockquote class="card-quote">
-      <p>&ldquo;<Fragment set:html={quote} />&rdquo;</p>
-      <cite>{cite}</cite>
-    </blockquote>
     <div class="tag-row">
       {tags.map(tag => <span class="tag">{tag}</span>)}
     </div>
-    {published && <a href={href} class="btn">Read Case Study</a>}
+    <a href={href} class="btn">Read Case Study</a>
   </div>
 </article>

--- a/src/components/WorkFeaturedAlt.astro
+++ b/src/components/WorkFeaturedAlt.astro
@@ -1,31 +1,26 @@
 ---
 /**
  * WorkFeaturedAlt.astro — specimen-forward featured card (2-column layout).
- * Left column: botanical specimen in the dark thumb.
- * Right column: label, title, research quote (replaces summary), tags, CTA.
+ * Left column: botanical specimen.
+ * Right column: label, title, tags, "Read Case Study" CTA.
  */
 interface Props {
   title: string;       // may contain HTML with <em>
   href: string;
   specimen?: string;   // specimen image path
-  specimenLight?: boolean; // true for white-bg PNGs → multiply blend mode
-  quote: string;       // research quote, no surrounding curly quotes
-  cite: string;
+  specimenLight?: boolean; // true for white-bg PNGs → cream thumb + multiply
   tags: string[];
-  published: boolean;
   label?: string;      // e.g. "Featured · 2026"
-  status?: string;     // shown when unpublished, e.g. "Contact me to view full portfolio"
 }
 
 const {
-  title, href, specimen, specimenLight = false, quote, cite, tags, published,
+  title, href, specimen, specimenLight = false, tags,
   label = 'Featured',
-  status = 'Contact me to view full portfolio',
 } = Astro.props;
 ---
 
-<article class={`project-featured project-featured--alt reveal${published ? ' has-link' : ''}`}>
-  <div class="project-thumb">
+<article class="project-featured project-featured--alt reveal has-link">
+  <div class={`project-thumb${specimenLight ? ' project-thumb--light' : ''}`}>
     {specimen && (
       <img
         class={`project-thumb-specimen${specimenLight ? ' project-thumb-specimen--light' : ''}`}
@@ -40,21 +35,11 @@ const {
   <div class="project-info">
     <span class="section-label">{label}</span>
     <h3 class="project-title">
-      {published
-        ? <a href={href} class="project-card-link"><Fragment set:html={title} /></a>
-        : <Fragment set:html={title} />
-      }
+      <a href={href} class="project-card-link"><Fragment set:html={title} /></a>
     </h3>
-    <blockquote class="card-quote card-quote--featured">
-      <p>&ldquo;<Fragment set:html={quote} />&rdquo;</p>
-      <cite>{cite}</cite>
-    </blockquote>
     <div class="tag-row">
       {tags.map(tag => <span class="tag">{tag}</span>)}
     </div>
-    {published
-      ? <a href={href} class="btn">Read Case Study</a>
-      : <span class="project-status">{status}</span>
-    }
+    <a href={href} class="btn">Read Case Study</a>
   </div>
 </article>

--- a/src/content/cases/sfpl.mdx
+++ b/src/content/cases/sfpl.mdx
@@ -12,7 +12,7 @@ tags:
   - 'Workshop Facilitation'
   - 'Public Sector'
 summary: 'Designing the internal conditions a five-year strategic plan needed to land, by turning 32 frontline and management staff into catalysts the leadership team could move with.'
-specimen: '/images/specimen-protea.jpg'
+specimen: '/images/specimen-orchid.png'
 slug: 'sfpl'
 status: 'published'
 ---

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -1,13 +1,9 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import { getCollection } from 'astro:content';
 import WorkCardAlt from '../components/WorkCardAlt.astro';
 import WorkFeaturedAlt from '../components/WorkFeaturedAlt.astro';
 // Original card components kept available:
 // import WorkCard from '../components/WorkCard.astro';
-
-const publishedCases = await getCollection('cases', entry => entry.data.status === 'published');
-const published = new Set(publishedCases.map(e => e.slug));
 
 const title = 'Work — Whitney Masulis';
 const description = 'Selected service design projects spanning insurance, public sector, automotive, telecom, and healthcare.';
@@ -34,10 +30,7 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
       title="Designing a caregiving benefit <em>for the sandwich generation.</em>"
       href="/cases/agetech.html"
       specimen="/images/specimen-rose.jpg"
-      quote="I just gave you all that information. What did I get for it?"
-      cite="Research participant, caregiver intake study"
       tags={['AgeTech', 'Prototyping AI', 'Service Blueprint', 'User Research']}
-      published={published.has('agetech')}
       label="Featured · 2026"
     />
 
@@ -49,20 +42,15 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
         title="From manual workaround <em>to scalable service at Allied Solutions.</em>"
         href="/cases/allied.html"
         specimen="/images/specimen-protea.jpg"
-        quote="6 to 8 weeks of waiting &mdash; mostly because of the billing system."
-        cite="Dealer, lender ecosystem research"
         tags={['Financial Services', 'Qualitative Research', 'Service Blueprint', 'Capabilities Map']}
-        published={published.has('allied')}
       />
 
       <WorkCardAlt
         title="A strategic plan <em>for the San Francisco Public Library.</em>"
         href="/cases/sfpl.html"
-        specimen="/images/specimen-protea.jpg"
-        quote="Things have changed so dramatically since the pandemic. You can feel it at every branch."
-        cite="Branch staff, ambassador series"
+        specimen="/images/specimen-orchid.png"
+        specimenLight={true}
         tags={['Public Sector', 'Workshop Design', 'Facilitation']}
-        published={published.has('sfpl')}
       />
 
       <WorkCardAlt
@@ -70,20 +58,14 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
         href="/cases/ai-lx.html"
         specimen="/images/specimen-paradise.png"
         specimenLight={true}
-        quote="AI in service of value &mdash; versus everyone in service of AI."
-        cite="Patrick Quattlebaum, engagement lead"
         tags={['Service Design', 'AI', 'Workshop Facilitation', 'Framework Design']}
-        published={published.has('ai-lx')}
       />
 
       <WorkCardAlt
         title="From &ldquo;make waiting feel better&rdquo; <em>to two prototypes in two real Ferguson branches.</em>"
         href="/cases/ferguson-cx.html"
         specimen="/images/specimen-ranunculus.jpg"
-        quote="Order not ready. Associate not present."
-        cite="The two wait-time scenarios"
         tags={['Service Design', 'Prototyping', 'Live Field Testing', 'Workshop Facilitation']}
-        published={published.has('ferguson-cx')}
       />
 
     </div>


### PR DESCRIPTION
## Summary

- **Remove quote + attribution from card body** — too confusing under the headline. Cards now show: specimen, title, tags, CTA.
- **Always render Read Case Study CTA + stretched-link** on every card. The draft/published distinction was hiding the CTA on the featured agetech card (which has `status: 'draft'`). Case page builds either way.
- **Paradise on AI-LX now visible** — white-bg specimens (paradise, orchid) use a cream thumb background instead of charcoal. Multiply on charcoal turned the flowers nearly black; multiply on cream lets the colors show.
- **SFPL specimen** swapped from protea (was duplicate of allied) to orchid as a placeholder. Need a kangaroo paw image to use the requested specimen.

## Outstanding

- Provide a kangaroo paw specimen image (drop into `public/images/specimen-kangaroo-paw.jpg|png`) and I'll wire it up for SFPL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)