### PR TITLE
Make all 7 cases live, show all on work page

### DIFF
--- a/src/content/cases/agetech.mdx
+++ b/src/content/cases/agetech.mdx
@@ -13,7 +13,7 @@ tags:
 summary: 'Building a functional AI prototype to test a caregiving service for working family caregivers, and learning that the medium itself is the design problem.'
 specimen: '/images/specimen-rose.jpg'
 slug: 'agetech'
-status: 'draft'
+status: 'published'
 ---
 import StatRow from '../../components/StatRow.astro';
 import PullQuote from '../../components/PullQuote.astro';

--- a/src/content/cases/ferguson-data.mdx
+++ b/src/content/cases/ferguson-data.mdx
@@ -12,6 +12,7 @@ tags:
   - 'Cross-functional Alignment'
   - 'Roadmapping'
 summary: 'Reframed an overwhelmed product-data team''s tooling problem as a service problem, mapped 275 steps across twelve roles, and produced a four-year roadmap that funded itself.'
+specimen: '/images/specimen-monarda.png'
 slug: 'ferguson-data'
 status: 'published'
 ---

--- a/src/content/cases/medical.mdx
+++ b/src/content/cases/medical.mdx
@@ -12,16 +12,16 @@ tags:
   - 'Workshop Facilitation'
   - 'Healthcare'
 summary: "Leading provider research inside an organization mid-transformation, where five stakeholders wanted five different things and the deliverable had to function as decision-making infrastructure for an org that didn't yet have any."
-specimen: '/images/specimen-amaranthus.jpg'
+specimen: '/images/specimen-passion.png'
 slug: 'medical'
-status: 'draft'
+status: 'published'
 ---
 import StatRow from '../../components/StatRow.astro';
 import InsightCallout from '../../components/InsightCallout.astro';
 import PullQuote from '../../components/PullQuote.astro';
 import Placeholder from '../../components/Placeholder.astro';
 
-<StatRow stats={[
+<StatRow variant="dark" stats={[
   { value: '13', label: 'Weeks' },
   { value: '10', label: 'Provider interviews moderated' },
   { value: '5', label: 'Stakeholders, five briefs' },

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -69,6 +69,22 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
         tags={['Service Design', 'Prototyping', 'Live Field Testing', 'Workshop Facilitation']}
       />
 
+      <WorkCardAlt
+        title="Treating product data as a service, <em>not a database.</em>"
+        href="/cases/ferguson-data.html"
+        specimen="/images/specimen-monarda.png"
+        specimenLight={true}
+        tags={['Service Design', 'Service Blueprinting', 'Data Strategy', 'Roadmapping']}
+      />
+
+      <WorkCardAlt
+        title="How do you lead research <em>for an organization learning to decide differently?</em>"
+        href="/cases/medical.html"
+        specimen="/images/specimen-passion.png"
+        specimenLight={true}
+        tags={['Service Design', 'Research Leadership', 'Journey Mapping', 'Healthcare']}
+      />
+
     </div>
   </section>
 </BaseLayout>


### PR DESCRIPTION
Final batch to make every case live and represented on the work page.

## Frontmatter changes

- **agetech.mdx**: \`status: draft → published\`
- **medical.mdx**: \`status: draft → published\`; specimen \`amaranthus → passion\`; StatRow gets \`variant=\"dark\"\`
- **ferguson-data.mdx**: adds \`specimen: '/images/specimen-monarda.png'\`

## Work page

Adds two \`<WorkCardAlt>\` entries to fill out the grid:

- **ferguson-data** — \"Treating product data as a service, *not a database.*\" — monarda specimen
- **medical** — \"How do you lead research *for an organization learning to decide differently?*\" — passion specimen

Both use \`specimenLight={true}\` for the white-bg PNGs.

## Result

All 7 cases are now \`status: published\` and represented on the work page (1 featured + 6 grid cards):

- Featured: agetech (rose)
- Grid: allied (protea), sfpl (orchid placeholder), ai-lx (paradise), ferguson-cx (celosia), ferguson-data (monarda), medical (passion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)