### PR TITLE
Restore V4 components and case body work lost during specimen-cards merge

### DIFF
--- a/src/components/BlueprintSlice.astro
+++ b/src/components/BlueprintSlice.astro
@@ -1,0 +1,289 @@
+---
+/**
+ * BlueprintSlice.astro — V4 design system, Harmonic methodology
+ *
+ * Renders a service-blueprint slice with stages as columns and methodology
+ * rows as horizontal lanes. Supports the full Harmonic row stack:
+ *
+ *   Customer Actions → Touchpoints → Frontstage Actions →
+ *   ─── Line of Visibility ───
+ *   Backstage Actions → Supporting Systems & Processes → Capabilities
+ *   (optional) Notes / Gaps / Questions / Pain
+ *
+ * Cells can be plain strings, or objects with chip styling (sage/gold/ink/
+ * deep/rust) for channel/touchpoint pills, plus optional `bigRock` flag for
+ * unresolved-question cells (orange highlight, per Harmonic convention).
+ *
+ * Rows can be flagged `highlight: true` to call attention as new — used in
+ * the AI-LX case to mark Frontstage AI and Backstage AI/ML rows as added
+ * actor swimlanes.
+ *
+ * Use one slice per case max. Don't try to render the whole blueprint —
+ * pick 4–6 stages, drop the columns the case doesn't need.
+ */
+interface Stage {
+  name: string;
+  /** Optional storyboard frame — emoji, short text, or `/images/...` URL */
+  storyboard?: string;
+}
+
+interface Cell {
+  content: string;
+  /** Chip color for channel / touchpoint pills */
+  chip?: 'sage' | 'gold' | 'ink' | 'deep' | 'rust';
+  /** Orange "big rock" treatment for unresolved-question cells */
+  bigRock?: boolean;
+}
+
+interface Row {
+  label: string;
+  /** Cells, one per stage. Use empty string for blank cells. */
+  cells: (string | Cell)[];
+  /** Visual variants — `highlight` = gold-tint label (for new AI rows, etc) */
+  variant?: 'default' | 'highlight' | 'pain';
+}
+
+interface Props {
+  /** Optional title above the table */
+  title?: string;
+  /** Optional caption below the table */
+  caption?: string;
+  /** Stage column definitions */
+  stages: Stage[];
+  /** Methodology rows in order */
+  rows: Row[];
+  /** 0-based index of the row AFTER which the LOV band appears. Default: no LOV. */
+  lovAfter?: number;
+}
+
+const { title, caption, stages, rows, lovAfter } = Astro.props;
+const totalCols = stages.length + 1; // +1 for the row label column
+
+function normalizeCell(c: string | Cell): Cell {
+  return typeof c === 'string' ? { content: c } : c;
+}
+---
+
+<figure class="v4-bp-figure">
+  {title && <h4 class="v4-bp-title">{title}</h4>}
+
+  <div class="v4-bp-wrap">
+    <table class="v4-bp">
+      <thead>
+        <tr>
+          <th>Stage</th>
+          {stages.map((s) => (
+            <th>
+              {s.storyboard && (
+                <span class="v4-bp-storyboard" aria-hidden="true">{s.storyboard}</span>
+              )}
+              <span>{s.name}</span>
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, idx) => (
+          <>
+            <tr class:list={[
+              row.variant === 'pain' && 'pain',
+              row.variant === 'highlight' && 'highlight',
+            ]}>
+              <th scope="row">
+                {row.variant === 'highlight' && (
+                  <span class="v4-bp-newtag" aria-hidden="true">NEW</span>
+                )}
+                {row.label}
+              </th>
+              {row.cells.map((c) => {
+                const cell = normalizeCell(c);
+                return (
+                  <td class:list={[cell.bigRock && 'big-rock']}>
+                    {cell.chip ? (
+                      <span class={`chip chip-${cell.chip}`}>{cell.content}</span>
+                    ) : (
+                      <span set:html={cell.content}></span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+            {lovAfter === idx && (
+              <tr class="lov">
+                <td colspan={totalCols}>
+                  <span class="lov-label">Line of visibility</span>
+                  <span class="lov-rule" aria-hidden="true"></span>
+                </td>
+              </tr>
+            )}
+          </>
+        ))}
+      </tbody>
+    </table>
+  </div>
+
+  {caption && <figcaption class="v4-bp-caption">{caption}</figcaption>}
+</figure>
+
+<style>
+  .v4-bp-figure {
+    margin: 2.5rem 0;
+  }
+  .v4-bp-title {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--charcoal, #2A2520);
+    margin: 0 0 12px 0;
+  }
+  .v4-bp-wrap {
+    overflow-x: auto;
+  }
+  .v4-bp {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+  }
+  .v4-bp th, .v4-bp td {
+    padding: 16px 18px;
+    text-align: left;
+    vertical-align: top;
+    line-height: 1.45;
+    color: var(--charcoal, #2A2520);
+    border-top: 1px solid var(--cream-deep, #EBE1D4);
+    border-bottom: 1px solid var(--cream-deep, #EBE1D4);
+  }
+  /* Stage column header row — Petrona 700 */
+  .v4-bp thead th {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--charcoal, #2A2520);
+    background: transparent;
+    padding-top: 14px;
+    padding-bottom: 14px;
+  }
+  .v4-bp-storyboard {
+    display: block;
+    font-size: 28px;
+    line-height: 1;
+    margin-bottom: 8px;
+    opacity: 0.85;
+  }
+  /* Row label (first col) — mono uppercase */
+  .v4-bp tbody th {
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 10px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--charcoal-soft, #6B6560);
+    font-weight: 500;
+    width: 13%;
+    background: transparent;
+    line-height: 1.4;
+    vertical-align: top;
+  }
+  /* Highlight variant — gold tint on the row label, "NEW" tag inline */
+  .v4-bp tr.highlight th {
+    background: rgba(200, 148, 62, 0.08);
+    color: var(--gold-text, #8A6820);
+  }
+  .v4-bp tr.highlight td {
+    background: rgba(200, 148, 62, 0.04);
+  }
+  .v4-bp-newtag {
+    display: inline-block;
+    background: var(--gold, #C8943E);
+    color: var(--charcoal, #2A2520);
+    font-size: 8px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    padding: 2px 6px;
+    border-radius: 2px;
+    margin-right: 8px;
+    vertical-align: 1px;
+  }
+  /* Line of visibility band — small-caps label above, dashed gold rule below */
+  .v4-bp .lov td {
+    border-top: none;
+    border-bottom: none;
+    padding: 22px 0 22px;
+    background: transparent;
+  }
+  .v4-bp .lov-label {
+    display: block;
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 10px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--gold-text, #8A6820);
+    font-weight: 500;
+    line-height: 1;
+    margin-bottom: 8px;
+  }
+  .v4-bp .lov-rule {
+    display: block;
+    height: 0;
+    border-top: 2.5px dashed var(--gold, #C8943E);
+  }
+  /* Pain row — italic charcoal-mid */
+  .v4-bp tr.pain td {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-style: italic;
+    font-weight: 500;
+    color: var(--charcoal-mid, #4A443D);
+    font-size: 14px;
+  }
+  .v4-bp tr.pain th {
+    color: var(--charcoal-soft, #6B6560);
+  }
+  /* Big rock — orange highlight for unresolved-question cells */
+  .v4-bp td.big-rock {
+    background: rgba(184, 92, 58, 0.10);
+    border-left: 3px solid var(--rust, #B85C3A);
+    position: relative;
+  }
+  .v4-bp td.big-rock::before {
+    content: 'BIG ROCK';
+    display: block;
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 8px;
+    letter-spacing: 0.16em;
+    color: var(--rust, #B85C3A);
+    font-weight: 700;
+    margin-bottom: 6px;
+  }
+  /* Chip pills */
+  .v4-bp .chip {
+    display: inline-block;
+    padding: 6px 11px;
+    border-radius: 3px;
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 9px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    font-weight: 500;
+    line-height: 1;
+    white-space: nowrap;
+  }
+  .v4-bp .chip-sage { background: var(--sage-light, #D4DEC9); color: var(--sage-text, #4A5C3F); }
+  .v4-bp .chip-gold { background: var(--gold, #C8943E); color: var(--charcoal, #2A2520); }
+  .v4-bp .chip-ink  { background: var(--ink, #1A1714); color: var(--cream, #F4EDE4); }
+  .v4-bp .chip-deep { background: var(--sage, #8B9A7E); color: var(--cream, #F4EDE4); }
+  .v4-bp .chip-rust { background: var(--rust, #B85C3A); color: var(--cream, #F4EDE4); }
+
+  .v4-bp-caption {
+    font-size: 13px;
+    color: var(--charcoal-mid, #4A443D);
+    line-height: 1.5;
+    margin-top: 12px;
+    font-style: italic;
+  }
+
+  /* Mobile: smaller padding, narrower row label column */
+  @media (max-width: 720px) {
+    .v4-bp th, .v4-bp td { padding: 10px 12px; font-size: 12px; }
+    .v4-bp tbody th { width: auto; min-width: 90px; }
+    .v4-bp thead th { font-size: 13px; }
+  }
+</style>

--- a/src/components/ExperimentCard.astro
+++ b/src/components/ExperimentCard.astro
@@ -1,0 +1,177 @@
+---
+/**
+ * ExperimentCard.astro — V4 design system
+ *
+ * Frames a single quantitative experiment. Gold header with charcoal text,
+ * cream body split 1 : 1.4 — left holds method + participants; right holds
+ * a 2×2 stat grid plus an optional participant verbatim.
+ *
+ * Use to anchor a discrete experiment moment in a case study (a cohort, a
+ * usability test, a controlled comparison). Keep stats to four for the grid
+ * to render cleanly.
+ */
+interface Stat {
+  /** Numeric or short value, e.g. "87%", "2.3×", "+34" */
+  num: string;
+  /** Mono-uppercase label below the value */
+  label: string;
+}
+
+interface Props {
+  /** Eyebrow text (e.g. "Experiment 03", "Cohort 1") — optional */
+  number?: string;
+  /** The experiment's question or title — italic display */
+  question: string;
+  /** Method description — paragraph */
+  method?: string;
+  /** Participants description — paragraph */
+  participants?: string;
+  /** Up to four stat cells. Renders as a 2×2 grid when ≥ 3 stats. */
+  stats?: Stat[];
+  /** Optional participant verbatim below the stats */
+  quote?: string;
+}
+
+const { number, question, method, participants, stats = [], quote } = Astro.props;
+---
+
+<div class="v4-exp">
+  <header class="v4-exp-head">
+    {number && <span class="v4-exp-eyebrow">{number}</span>}
+    <span class="v4-exp-title" set:html={question}></span>
+  </header>
+  <div class="v4-exp-body">
+    <div class="v4-exp-meta">
+      {method && (
+        <div class="v4-exp-meta-block">
+          <div class="v4-exp-meta-h">Method</div>
+          <div class="v4-exp-meta-p">{method}</div>
+        </div>
+      )}
+      {participants && (
+        <div class="v4-exp-meta-block">
+          <div class="v4-exp-meta-h">Participants</div>
+          <div class="v4-exp-meta-p">{participants}</div>
+        </div>
+      )}
+    </div>
+    <div class="v4-exp-right">
+      {stats.length > 0 && (
+        <div class="v4-exp-stats">
+          {stats.map((s) => (
+            <div>
+              <span class="v4-exp-stat-num">{s.num}</span>
+              <span class="v4-exp-stat-lab">{s.label}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      {quote && <p class="v4-exp-quote">{quote}</p>}
+    </div>
+  </div>
+</div>
+
+<style>
+  .v4-exp {
+    border-radius: 12px;
+    overflow: hidden;
+    margin: 2.5rem 0;
+  }
+  .v4-exp-head {
+    background: var(--gold, #C8943E);
+    color: var(--charcoal, #2A2520);
+    padding: 28px 32px 30px;
+  }
+  .v4-exp-eyebrow {
+    display: block;
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 10px;
+    line-height: 1;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    font-weight: 500;
+    color: var(--charcoal, #2A2520);
+    opacity: 0.78;
+    margin-bottom: 14px;
+  }
+  .v4-exp-title {
+    display: block;
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 22px;
+    font-weight: 700;
+    line-height: 1.3;
+    color: var(--charcoal, #2A2520);
+    letter-spacing: -0.005em;
+    max-width: 760px;
+  }
+  .v4-exp-body {
+    background: var(--cream, #F4EDE4);
+    padding: 30px 32px 32px;
+    display: grid;
+    grid-template-columns: 1fr 1.4fr;
+    gap: 36px;
+  }
+  @media (max-width: 720px) {
+    .v4-exp-body {
+      grid-template-columns: 1fr;
+      gap: 24px;
+    }
+  }
+  .v4-exp-meta-block + .v4-exp-meta-block { margin-top: 18px; }
+  .v4-exp-meta-h {
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 9px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--charcoal-soft, #6B6560);
+    margin-bottom: 8px;
+  }
+  .v4-exp-meta-p {
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--charcoal, #2A2520);
+    max-width: none;
+  }
+  .v4-exp-right {
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+  }
+  .v4-exp-stats {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 22px 28px;
+  }
+  .v4-exp-stat-num {
+    display: block;
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-style: italic;
+    font-weight: 700;
+    font-size: 30px;
+    line-height: 1;
+    color: var(--gold-text, #8A6820);
+    margin-bottom: 6px;
+    letter-spacing: -0.01em;
+  }
+  .v4-exp-stat-lab {
+    display: block;
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 9px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--charcoal-soft, #6B6560);
+    line-height: 1.4;
+  }
+  .v4-exp-quote {
+    border-top: 1px solid var(--cream-deep, #EBE1D4);
+    padding-top: 18px;
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-style: italic;
+    font-weight: 500;
+    font-size: 15px;
+    line-height: 1.45;
+    color: var(--charcoal-mid, #4A443D);
+    max-width: none;
+    margin: 0;
+  }
+</style>

--- a/src/components/GPTConversation.astro
+++ b/src/components/GPTConversation.astro
@@ -1,0 +1,156 @@
+---
+/**
+ * GPTConversation.astro — V4 design system
+ *
+ * Renders an AI/human chat exchange as semantic chat bubbles. Use to show
+ * the actual behaviour of an AI service prototype rather than a screenshot.
+ *
+ * Layout: dark header strip, role labels OUTSIDE the bubbles, AI messages
+ * left-aligned with cream border, human messages right-aligned in gold-pale.
+ * Optional annotation callout below the conversation.
+ */
+interface Message {
+  /** Role label shown above the bubble (e.g. "Coach", "Caregiver", "AI") */
+  role: string;
+  /** Which side of the conversation — controls bubble style and alignment */
+  speaker: 'ai' | 'user';
+  /** Message text. May contain inline <strong>...</strong> to bold a phrase. */
+  text: string;
+}
+
+interface Props {
+  /** Header label (e.g. "Caregiving onboarding · prototype") */
+  header?: string;
+  /** The messages, in order, top to bottom */
+  messages: Message[];
+  /** Optional annotation callout below the conversation */
+  annotation?: {
+    title: string;
+    body: string;
+  };
+}
+
+const { header, messages, annotation } = Astro.props;
+---
+
+<div class="v4-gpt-wrap">
+  <div class="v4-gpt">
+    {header && (
+      <header class="v4-gpt-head">
+        <span class="v4-gpt-dot" aria-hidden="true"></span>
+        <span>{header}</span>
+      </header>
+    )}
+    <div class="v4-gpt-body">
+      {messages.map((m) => (
+        <div class={`v4-gpt-msg is-${m.speaker}`}>
+          <span class="v4-gpt-role">{m.role}</span>
+          <div class="v4-gpt-bubble" set:html={m.text}></div>
+        </div>
+      ))}
+    </div>
+  </div>
+
+  {annotation && (
+    <aside class="v4-gpt-annot">
+      <div class="v4-gpt-annot-title">{annotation.title}</div>
+      <p class="v4-gpt-annot-body">{annotation.body}</p>
+    </aside>
+  )}
+</div>
+
+<style>
+  .v4-gpt-wrap {
+    margin: 2.5rem 0;
+  }
+  .v4-gpt {
+    background: var(--warm-white, #FAF7F3);
+    border: 1px solid var(--cream-deep, #EBE1D4);
+    border-radius: 12px;
+    overflow: hidden;
+    max-width: 560px;
+  }
+  .v4-gpt-head {
+    background: var(--ink, #1A1714);
+    color: var(--cream, #F4EDE4);
+    padding: 14px 22px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 12px;
+    letter-spacing: 0.04em;
+  }
+  .v4-gpt-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--gold-light, #D4A85A);
+    flex-shrink: 0;
+  }
+  .v4-gpt-body {
+    padding: 26px 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+  .v4-gpt-msg {
+    display: flex;
+    flex-direction: column;
+    max-width: 78%;
+  }
+  .v4-gpt-msg.is-user { align-self: flex-end; align-items: flex-end; }
+  .v4-gpt-msg.is-ai   { align-self: flex-start; align-items: flex-start; }
+  .v4-gpt-role {
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 9px;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+    padding: 0 16px;
+  }
+  .v4-gpt-msg.is-user .v4-gpt-role { color: var(--gold-text, #8A6820); }
+  .v4-gpt-msg.is-ai   .v4-gpt-role { color: var(--charcoal-soft, #6B6560); }
+  .v4-gpt-bubble {
+    padding: 14px 18px;
+    border-radius: 8px;
+    font-size: 13px;
+    line-height: 1.55;
+    color: var(--charcoal, #2A2520);
+  }
+  .v4-gpt-msg.is-user .v4-gpt-bubble {
+    background: var(--gold-pale, #F0E4CC);
+    color: var(--charcoal, #2A2520);
+  }
+  .v4-gpt-msg.is-ai .v4-gpt-bubble {
+    background: var(--warm-white, #FAF7F3);
+    border: 1px solid var(--cream-deep, #EBE1D4);
+    color: var(--charcoal-mid, #4A443D);
+  }
+  .v4-gpt-bubble :global(strong) {
+    color: var(--charcoal, #2A2520);
+    font-weight: 700;
+  }
+
+  .v4-gpt-annot {
+    background: var(--gold-pale, #F0E4CC);
+    border-left: 3px solid var(--gold, #C8943E);
+    padding: 16px 20px;
+    margin-top: 18px;
+    max-width: 560px;
+    border-radius: 4px;
+  }
+  .v4-gpt-annot-title {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--charcoal, #2A2520);
+    margin-bottom: 4px;
+  }
+  .v4-gpt-annot-body {
+    font-size: 12.5px;
+    line-height: 1.55;
+    color: var(--charcoal-mid, #4A443D);
+    margin: 0;
+  }
+</style>

--- a/src/content/cases/agetech.mdx
+++ b/src/content/cases/agetech.mdx
@@ -19,6 +19,8 @@ import StatRow from '../../components/StatRow.astro';
 import PullQuote from '../../components/PullQuote.astro';
 import InsightCallout from '../../components/InsightCallout.astro';
 import BotanicalDivider from '../../components/BotanicalDivider.astro';
+import GPTConversation from '../../components/GPTConversation.astro';
+import ExperimentCard from '../../components/ExperimentCard.astro';
 
 <StatRow variant="dark" stats={[
   { value: '50M+', label: 'U.S. family caregivers' },
@@ -86,10 +88,31 @@ These are not easy questions. Describing a parent's cognitive decline, financial
 The system prompt enforced the questionnaire architecture and the compassionate language framework simultaneously. These aren't prompt-engineering decisions. They're service design decisions about how this service speaks to people in pain.
 </InsightCallout>
 
-<figure>
-  <img src="/images/agetech-gpt-conversation.png" alt="Redacted transcript from the prototype in use, showing the GPT walking a caregiver named Paloma through questions about her care recipient Ivanka — name, age, health conditions (with examples like 'dementia or Alzheimer's,' 'heart disease,' 'cancer'), diagnosis dates, communication preference (direct / gentle / slow), and household composition." />
-  <figcaption>A slice of the prototype in use during testing. Names anonymized.</figcaption>
-</figure>
+<GPTConversation
+  header="Caregiving onboarding · prototype"
+  messages={[
+    {
+      role: 'Coach',
+      speaker: 'ai',
+      text: "Got it — thanks. Before we go further, can you tell me a little about who you're caring for, and how this past week has been?"
+    },
+    {
+      role: 'Caregiver',
+      speaker: 'user',
+      text: "My dad. We can't get him to stop driving. He hides the keys."
+    },
+    {
+      role: 'Coach',
+      speaker: 'ai',
+      text: "<strong>Driving</strong> is one of the most common conflict points when an older parent is showing early cognitive change. Was there a specific moment that brought it up today, or has it been building for a while?"
+    },
+    {
+      role: 'Caregiver',
+      speaker: 'user',
+      text: "It's been building. I just don't know how to take the keys without making him feel like he's lost everything."
+    }
+  ]}
+/>
 
 The geriatric-care persona caught phrasing late in the build that I wished I'd had it review earlier: clinical staging language that had crept in, words that read as neutral to me but landed as judgment to a caregiver. Bring the harshest critical lens in at the start, not the end.
 
@@ -104,6 +127,14 @@ That reframed how I thought about language in this context. It's not enough to c
 We ran two cohorts in March 2026: twelve caregivers total, recruited through an online research platform. All were employed full-time and actively caring for an aging family member.
 
 ### Cohort 1: the experience in the wrong order
+
+<ExperimentCard
+  number="Cohort 1"
+  question="Will caregivers stay engaged through deep intake questions if value is delivered after?"
+  method="Moderated remote test, six caregivers, March 2026. Original flow: intake first, profiles + forecast after, situational guidance last."
+  participants="Employed full-time, actively caring for an aging family member."
+  quote="I just gave you all that information. What did I get for it?"
+/>
 
 The original flow front-loaded data collection so the team could take the outputs and manually load them into the wireframes. Participants answered questions one at a time and then, at the end, were shown a profile for their loved one and a profile for themselves. The profiles fell flat. After investing so much time in deeply personal questions, participants were shown summaries of information they already knew. The forecasts came next, as a static wireframe with only one tab open per time horizon, so they saw a fraction of the information. Reactions were tepid rather than excited. Then a dashboard, which they again read as a summary of what they'd told us. The feature they were most excited about — situational guidance where they could ask the chatbot about their specific caregiving challenges — came last.
 
@@ -142,6 +173,14 @@ Between cohorts, I redesigned the flow entirely. Instead of starting with intake
 </InsightCallout>
 
 ## Cohort 2 leaned in. *One session in particular.*
+
+<ExperimentCard
+  number="Cohort 2"
+  question="Will guidance-first delivery change how caregivers engage with the prototype?"
+  method="Same protocol, six new caregivers, March 2026. Redesigned flow: chatbot guidance modes first, intake consolidated and shown after."
+  participants="Employed full-time, actively caring for an aging family member. No overlap with cohort 1."
+  quote="We can't get him to stop. — Note from the session, after the executive sponsor stopped evaluating and started using it."
+/>
 
 The difference was immediate. Participants leaned in. In almost every session, we had to tell them we needed to move on because they kept wanting to ask the AI more questions. Several said they learned something they hadn't known before. Nobody asked what they were getting in exchange for sharing so much personal information. That last point mattered as much as anything else: the interaction felt worth it to them.
 

--- a/src/content/cases/ai-lx.mdx
+++ b/src/content/cases/ai-lx.mdx
@@ -21,8 +21,9 @@ import PullQuote from '../../components/PullQuote.astro';
 import InsightCallout from '../../components/InsightCallout.astro';
 import BotanicalDivider from '../../components/BotanicalDivider.astro';
 import Placeholder from '../../components/Placeholder.astro';
+import BlueprintSlice from '../../components/BlueprintSlice.astro';
 
-<StatRow variant="dark" stats={[
+<StatRow stats={[
   { value: '50', label: 'Designers, researchers, executives' },
   { value: '2 days', label: 'Workshop, full team' },
   { value: '4', label: 'Dimensions framework authored' },
@@ -159,10 +160,102 @@ The third workshop framework was an adaptation of standard service blueprinting.
 
 This sounds small. It does meaningful work. Once an AI is named as an actor, the team has to articulate what it's doing, what it has agency over, where the handoffs to humans live, and where the orchestration sits. That is exactly the conversation the team was avoiding by collapsing AI into "the system."
 
-<figure>
-  <img src="/images/ai-lx-service-blueprint.jpg" alt="An adapted service-blueprint template with eight horizontal rows: MTMs, Customer Actions, Touchpoints (with Non-AI / AI / Hybrid checkboxes), Frontstage Actions: Human Actors, Frontstage Actions: AI Agents, Line of Visibility, Backstage Actions: Human Actors, Backstage Actions: AI Agents, and Supporting AI Systems. Each touchpoint and AI-actor row has structured fields underneath." />
-  <figcaption>The adapted blueprint. Within each stage, human and AI actors get their own rows, so the team has to articulate what each is doing rather than collapsing AI into "the system."</figcaption>
-</figure>
+<BlueprintSlice
+  title="Adapted blueprint slice — buying a car online"
+  caption='Two new rows ("Frontstage AI" and "Backstage AI / ML") sit alongside their human counterparts. Once AI is named as an actor, the team has to say what it does, where its authority ends, and what the human handoff looks like. Capabilities track the underlying competence each cell depends on. The orange "big rock" cell is a question the room could not resolve — captured, not smoothed over.'
+  stages={[
+    { name: 'Discover' },
+    { name: 'Compare' },
+    { name: 'Trust' },
+    { name: 'Configure' },
+    { name: 'Commit' }
+  ]}
+  lovAfter={4}
+  rows={[
+    {
+      label: 'Customer action',
+      cells: [
+        'Browses inventory from phone after work',
+        'Narrows down to 3–5 vehicles, compares specs',
+        'Asks questions about a specific car',
+        'Inputs trade-in info; picks a financing path',
+        'Reviews terms and signs digitally'
+      ]
+    },
+    {
+      label: 'Touchpoint',
+      cells: [
+        { content: 'Mobile web', chip: 'sage' },
+        { content: 'Compare view', chip: 'sage' },
+        { content: 'Chat · Vehicle page', chip: 'gold' },
+        { content: 'Financing form', chip: 'gold' },
+        { content: 'Checkout', chip: 'ink' }
+      ]
+    },
+    {
+      label: 'Frontstage · Human',
+      cells: [
+        '—',
+        '—',
+        'Sales associate available on request',
+        'Financing specialist consults if asked',
+        'Delivery coordinator confirms pickup'
+      ]
+    },
+    {
+      label: 'Frontstage · AI',
+      variant: 'highlight',
+      cells: [
+        'Personalized vehicle recommendations from browse history (ML)',
+        'Side-by-side comparison highlighting tradeoffs the customer hasn\'t named',
+        { content: 'Should the AI ever recommend AGAINST a purchase if data suggests poor fit? Needs ethics + comms.', bigRock: true },
+        'Conversational pre-qualification surfaces options without a hard credit pull',
+        'Adaptive UI surfaces likely concerns based on hesitation patterns'
+      ]
+    },
+    {
+      label: 'Backstage · Human',
+      cells: [
+        'Marketing & pricing analysts',
+        'Inventory ops, merchandising',
+        'Customer support specialists',
+        'Underwriters, fraud review (escalations)',
+        'Fulfillment, transport coordination'
+      ]
+    },
+    {
+      label: 'Backstage · AI / ML',
+      variant: 'highlight',
+      cells: [
+        'Inventory matching ML; demand forecasting',
+        'Dynamic pricing model; comparison ranking',
+        'Intent classification routes the right knowledge to the right surface',
+        'Risk-scoring model returns indicative pre-qualification',
+        'Fraud detection; fulfillment routing optimization'
+      ]
+    },
+    {
+      label: 'Supporting systems',
+      cells: [
+        'Inventory DB · ad platforms',
+        'Vehicle history APIs · comparison engine',
+        'CRM · chat platform',
+        'Lender integrations · valuation APIs',
+        'Payment processor · DMV / titling'
+      ]
+    },
+    {
+      label: 'Capabilities',
+      cells: [
+        'Personalization · behavioral analytics',
+        'Comparative reasoning · pricing intelligence',
+        'Knowledge retrieval · source attribution',
+        'Risk underwriting · conversational interfaces',
+        'Identity verification · electronic contracting'
+      ]
+    }
+  ]}
+/>
 
 ## The pedagogy: paper, sketches, no laptops
 

--- a/src/content/cases/allied.mdx
+++ b/src/content/cases/allied.mdx
@@ -17,11 +17,12 @@ slug: 'allied'
 status: 'published'
 ---
 import StatRow from '../../components/StatRow.astro';
-import PullQuote from '../../components/PullQuote.astro';
 import InsightCallout from '../../components/InsightCallout.astro';
 import BotanicalDivider from '../../components/BotanicalDivider.astro';
 import DarkBand from '../../components/DarkBand.astro';
 import Placeholder from '../../components/Placeholder.astro';
+import BlueprintSlice from '../../components/BlueprintSlice.astro';
+import PullQuote from '../../components/PullQuote.astro';
 
 <StatRow variant="dark" stats={[
   { value: '9 months', label: 'Engagement length' },
@@ -85,6 +86,112 @@ The blueprint did one thing on purpose that's easy to miss in a static deliverab
 <PullQuote>
 The blueprint told the truth about what wasn't decided yet, and named who would need to decide it.
 </PullQuote>
+
+<BlueprintSlice
+  title="One slice of the future-state blueprint — a single refund moving through the service"
+  caption='Multi-actor: lender, dealer, and provider each have rows alongside Allied. The Status Milestone row is the case&apos;s distinctive move — it tracks how a refund&apos;s state should be represented through the entire flow, not just at the end. The orange "big rock" cell is the kind of unresolved question the workshop kept on the blueprint instead of smoothing over.'
+  stages={[
+    { name: 'Cancellation initiated' },
+    { name: 'Documentation collected' },
+    { name: 'Refund calculated' },
+    { name: 'Funds transferred' },
+    { name: 'Status closed' }
+  ]}
+  lovAfter={5}
+  rows={[
+    {
+      label: 'Lender action',
+      cells: [
+        'Lender flags cancellation in their loan system',
+        'Lender confirms loan + product data sent to Allied',
+        '—',
+        'Lender confirms funds received and reconciled',
+        'Lender closes the case in their system of record'
+      ]
+    },
+    {
+      label: 'Dealer action',
+      cells: [
+        '—',
+        'Dealer surfaces original product data on request',
+        '—',
+        '—',
+        'Dealer is notified the case is closed'
+      ]
+    },
+    {
+      label: 'Provider action',
+      cells: [
+        'Provider receives the cancellation event',
+        'Provider validates the refund is owed',
+        'Provider calculates the refund amount per their formula',
+        'Provider issues funds to Allied for routing',
+        '—'
+      ]
+    },
+    {
+      label: 'Touchpoint',
+      cells: [
+        { content: 'Allied portal · API event', chip: 'sage' },
+        { content: 'Allied portal · doc upload', chip: 'sage' },
+        { content: 'Provider system · API', chip: 'gold' },
+        { content: 'EFT · status portal', chip: 'gold' },
+        { content: 'Status portal · email', chip: 'ink' }
+      ]
+    },
+    {
+      label: 'Frontstage · Allied',
+      cells: [
+        'Allied confirms receipt and sets case in motion',
+        'Allied checks documentation against requirements; pings lender if anything is missing',
+        'Allied surfaces calculation status to lender; flags exceptions',
+        'Allied executes EFT and updates the status portal in real time',
+        'Allied confirms close-out and stops the clock against the regulatory deadline'
+      ]
+    },
+    {
+      label: 'Status milestone',
+      variant: 'highlight',
+      cells: [
+        { content: 'Cancellation pending', chip: 'gold' },
+        { content: 'Awaiting documentation', chip: 'gold' },
+        { content: 'Calculation in progress', chip: 'gold' },
+        { content: 'Payment in progress', chip: 'gold' },
+        { content: 'Closed within window', chip: 'gold' }
+      ]
+    },
+    {
+      label: 'Backstage · Allied',
+      cells: [
+        'Case-management workflow opens with auto-assigned owner',
+        'Documentation team works exceptions; calls lender as needed',
+        { content: 'Should Allied own the calculation logic, or pass it through from the provider? Open question — has implications for liability.', bigRock: true },
+        'Treasury operations reconciles inbound funds and triggers EFT to lender',
+        'Reporting captures cycle time vs. regulatory deadline'
+      ]
+    },
+    {
+      label: 'Supporting systems',
+      cells: [
+        'Case-management platform · lender API',
+        'Document store · lender portal',
+        'Calculation engine · provider integrations',
+        'Treasury system · ACH provider',
+        'Reporting · audit log'
+      ]
+    },
+    {
+      label: 'Capabilities',
+      cells: [
+        'Multi-channel intake; case auto-routing',
+        'Documentation requirements engine; exception handling',
+        'Refund calculation; provider integration management',
+        'Funds movement; status transparency to lender',
+        'Cycle-time reporting; regulatory compliance evidence'
+      ]
+    }
+  ]}
+/>
 
 <DarkBand label="The future-state artifacts">
 

--- a/src/content/cases/ferguson-data.mdx
+++ b/src/content/cases/ferguson-data.mdx
@@ -21,6 +21,7 @@ import PullQuote from '../../components/PullQuote.astro';
 import InsightCallout from '../../components/InsightCallout.astro';
 import BotanicalDivider from '../../components/BotanicalDivider.astro';
 import Placeholder from '../../components/Placeholder.astro';
+import BlueprintSlice from '../../components/BlueprintSlice.astro';
 
 <StatRow variant="dark" stats={[
   { value: '12', label: 'Stakeholder roles mapped' },
@@ -65,8 +66,8 @@ The work began by partnering with the core product-data team and then deliberate
 Twelve roles came out of those conversations. The resulting experience map ran past 275 steps. It was the first time anyone at Ferguson had seen the full path a single product record travels, from a vendor's hands to a customer's order.
 
 <figure>
-  <img src="/images/ferguson-data-grapes.jpg" alt="A 'Data Grapes' diagram: large purple bubbles representing types of enterprise data — Vendor Data, Product Data (with Critical Attributes labeled inside), Customer Data, Sales 'transaction' Data, Pricing Data, Marketing Data, Associate Data, Program Data — connected with thin arrows showing dependencies; smaller green and yellow stickies clustered around them tagging specific systems (TMS, WMS, PIM, VRM, CPQ, ERP, BI, HRIS) and notes." />
-  <figcaption>"Data Grapes" — the structure of enterprise data behind a single product record. Each bubble is a domain that touches the same record but rarely shares a vocabulary.</figcaption>
+  <img src="/images/ferguson-data-types.jpg" alt="A 'Data Types' diagram: large purple bubbles representing types of enterprise data — Vendor Data, Product Data (with Critical Attributes labeled inside), Customer Data, Sales 'transaction' Data, Pricing Data, Marketing Data, Associate Data, Program Data — connected with thin arrows showing dependencies; smaller green and yellow stickies clustered around them tagging specific systems (TMS, WMS, PIM, VRM, CPQ, ERP, BI, HRIS) and notes." />
+  <figcaption>"Data Types" — the structure of enterprise data behind a single product record. Each bubble is a domain that touches the same record but rarely shares a vocabulary.</figcaption>
 </figure>
 
 That map became the working surface for everything downstream:
@@ -74,6 +75,91 @@ That map became the working surface for everything downstream:
 - **Opportunity workshops.** The internal team used the map to prioritize problems, surface opportunities, and develop concepts for a new ingestion-and-enrichment service. Putting the operators at the design table was load-bearing. They would have to run the new system, so they had to help build it.
 - **Service blueprinting.** Cross-functional sessions translated the prioritized opportunities into a future-state service, with the front-stage and backstage detail required to actually run it. This is where "what could be different" turned into "what we'd have to build, hire, retrain, or buy."
 - **Evolution mapping.** A backcast across three time horizons sequenced the capabilities the future-state service would need, so the program could be phased without losing coherence.
+
+<BlueprintSlice
+  title="One slice of the future-state blueprint — onboarding a new supplier to the product-data systems"
+  caption="Pulled from one of the future-state blueprints. Each cell on the Capability row represents one of the 290+ capabilities the program had to enumerate to operationalize the future state. The orange big rock is one of the kind of unresolved questions the workshop kept on the blueprint instead of papering over."
+  stages={[
+    { name: 'Review guidelines' },
+    { name: 'Sign agreement' },
+    { name: 'Train & assess' },
+    { name: 'Submit sample data' },
+    { name: 'System onboarding' }
+  ]}
+  lovAfter={3}
+  rows={[
+    {
+      label: 'Supplier action',
+      cells: [
+        'Reviews the published product-data guidelines',
+        'Signs the data-sharing requirements agreement',
+        'Completes training modules and the data-maturity questionnaire',
+        'Submits a sample data set through the supplier-facing tool',
+        'Joins the assessment review and onboards into Ferguson systems'
+      ]
+    },
+    {
+      label: 'Ferguson · Sponsor / SSR',
+      cells: [
+        'Sponsor shares published guidelines with the supplier',
+        'Sponsor walks the supplier through the agreement',
+        'Supplier Success Rep schedules and runs the data-maturity meeting',
+        'SSR runs the sample through the matching tool with the supplier',
+        'SSR runs the assessment review and shares recommendations'
+      ]
+    },
+    {
+      label: 'Touchpoint',
+      cells: [
+        { content: 'Published guidelines doc', chip: 'sage' },
+        { content: 'Supplier-facing system', chip: 'sage' },
+        { content: 'Meeting · training portal', chip: 'gold' },
+        { content: 'Sample-data submission tool', chip: 'gold' },
+        { content: 'Assessment meeting · onboarding portal', chip: 'ink' }
+      ]
+    },
+    {
+      label: 'Backstage action',
+      cells: [
+        'Sponsor logs the relationship in CRM',
+        'Legal review on terms; agreement filed',
+        'Data team prepares supplier-specific training; questionnaire scored',
+        { content: 'Should the SSR or the supplier own remediation when sample data fails the maturity check? Open question — affects staffing model.', bigRock: true },
+        'Onboarding team provisions accounts; data team validates first production load'
+      ]
+    },
+    {
+      label: 'Systems',
+      cells: [
+        'Documentation portal · CRM',
+        'Supplier-facing system · contract management',
+        'Training portal · maturity assessment tool',
+        'Submission tool · data-matching engine',
+        'PIM · onboarding orchestration · monitoring'
+      ]
+    },
+    {
+      label: 'Policies & processes',
+      cells: [
+        'Data quality standards (published)',
+        'Data-sharing agreement template; legal review SLA',
+        'Training requirement; maturity threshold',
+        'Sample-data privacy controls; matching review SLA',
+        'Onboarding sign-off criteria; first-90-days monitoring'
+      ]
+    },
+    {
+      label: 'Capability',
+      cells: [
+        'Supplier-facing publishing; guideline versioning',
+        'Self-serve agreement workflow; legal e-sign',
+        'Adaptive training delivery; maturity scoring',
+        'Sample-data ingestion; automated matching feedback',
+        'Onboarding orchestration; supplier health monitoring'
+      ]
+    }
+  ]}
+/>
 
 <BotanicalDivider />
 


### PR DESCRIPTION
## What happened

When the specimen-cards / V4 dark-thumb branch (PR #56) merged to main, it was based on an older snapshot of each case from before the V4 component work (\`GPTConversation\`, \`ExperimentCard\`, \`BlueprintSlice\`) landed. That merge overwrote the case bodies with the older versions, and the three new \`.astro\` component files weren't carried over either.

This restores all of that.

## What this PR brings back

**Component files** (in \`src/components/\`):
- \`GPTConversation.astro\` — chat-bubble layout, dark header, role labels outside bubbles
- \`ExperimentCard.astro\` — gold-headed experiment frame with method/participants + 2×2 stat grid + verbatim
- \`BlueprintSlice.astro\` — full Harmonic methodology row support (Customer Actions / Touchpoints / Frontstage / LOV / Backstage / Supporting Systems / Capabilities), with chip styling, big-rock cells, and highlight-row variant for new actor swimlanes

**Case body restorations:**
- **agetech** — GPT screenshot replaced with \`<GPTConversation>\` (driving-cessation exchange, anonymized). Two \`<ExperimentCard>\` blocks at the cohort 1 and cohort 2 sections.
- **ai-lx** — Empty service-blueprint template image replaced with a populated \`<BlueprintSlice>\` walking through a five-stage online car-buying flow with two highlighted AI actor rows (Frontstage AI, Backstage AI/ML) and one orange big-rock cell.
- **allied** — \`<BlueprintSlice>\` between the promoted PullQuote and the DarkBand showing one refund moving through the future-state service, with the highlighted Status Milestone row (the case's distinctive move) and one big-rock cell in Backstage Allied.
- **ferguson-data** — \`<BlueprintSlice>\` after the Data Types figure, showing the supplier-onboarding scenario with a Capability row anchoring the "290+ capabilities" claim.

## Frontmatter merging

Reflog versions had the V4 dark stat row and (where applicable) the V4 specimens. Where main had moved past the reflog version, I patched in the newer state:

- agetech: flipped \`status: draft → published\`
- ai-lx: added \`specimen: '/images/specimen-paradise.png'\`
- allied + ferguson-data: clean — reflog versions were current

## Cases not affected

medical, ferguson-cx, sfpl didn't lose anything. Medical still has its inline interview-architecture grid diagram intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)