### PR TITLE
Re-apply dark thumb backgrounds and dimmed PNG specimens

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -443,10 +443,16 @@ p + p { margin-top: var(--sp-2); }
    (Multiply on charcoal turns colored flowers nearly black; cream lets them show.) */
 .project-card--alt .project-thumb--light,
 .project-featured--alt .project-thumb--light {
-  background: var(--cream);
+  background: var(--charcoal);
 }
+/* The "light" PNG specimens have transparent backgrounds, so no blend
+   mode is needed to drop the bg. Instead, dim and desaturate the flower
+   directly so it reads as moody/restrained — matching the dark-room
+   feel of the rose / protea JPGs rather than glowing against charcoal.
+   Tuned: brightness(0.8) saturate(0.85) — landed between "too dim" and
+   "too glowing". */
 .project-thumb-specimen--light {
-  mix-blend-mode: multiply;
+  filter: brightness(0.8) saturate(0.85);
   opacity: 1;
 }
 


### PR DESCRIPTION
Reapplies the CSS tuning that was on the all-cases-live branch but didn't make it into PR #59 (that PR merged earlier, before this work landed on the branch).

`.project-thumb--light` background: cream → charcoal.
`.project-thumb-specimen--light` blend mode → `filter: brightness(0.8) saturate(0.85)`.

Result: all 7 work cards render on dark thumbs with PNG specimens dimmed to a moody register matching the rose/protea JPGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)