### PR TITLE
Hide ferguson-data card from work page

### DIFF
--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -69,13 +69,7 @@ const canonicalURL = 'https://whitneyesque.github.io/work.html';
         tags={['Service Design', 'Prototyping', 'Live Field Testing', 'Workshop Facilitation']}
       />
 
-      <WorkCardAlt
-        title="Treating product data as a service, <em>not a database.</em>"
-        href="/cases/ferguson-data.html"
-        specimen="/images/specimen-monarda.png"
-        specimenLight={true}
-        tags={['Service Design', 'Service Blueprinting', 'Data Strategy', 'Roadmapping']}
-      />
+      {/* ferguson-data hidden — set status back to published in work.astro to restore */}
 
       <WorkCardAlt
         title="How do you lead research <em>for an organization learning to decide differently?</em>"


### PR DESCRIPTION
Removes the ferguson-data WorkCardAlt from work.astro. Restore by uncommenting the block when ready.