### PR TITLE
V4 design system: data-viz

### DIFF
--- a/handoff/data-viz.md
+++ b/handoff/data-viz.md
@@ -1,0 +1,49 @@
+# Design-system-applier handoff — data-viz
+
+## Layout archetype
+
+**6-section / Minimal** (with one V4 visual hinge added).
+
+Reason: this is a narrative-led case about a single methodology shift (using agentic AI as a working business analyst), not a research- and process-heavy engagement with multiple prototypes or frameworks. The Sample 1 archetype fits: hero + StatRow → problem context → approach → process detail → DarkBand visual hinge → output description → takeaways → reflection.
+
+## Components used (count 5 of 6 cap)
+
+- **StatRow** (variant="dark") — directly under the hero. Carries the four key numbers from the synthesized deliverable (821 ratings, 40 themes, 7 critical themes, 1 service designer doing analyst work). The fourth stat is the case's thesis stated as a number.
+- **BotanicalDivider** — placed once at the narrative hinge between the conventional-synthesis section and the "what I did differently" section, marking the pivot from "we did the votes" to "I gave the data to Claude Code."
+- **PullQuote** ×2 — first one is Whitney quoting her own brief to Claude (the operating instructions that made the iteration work); second one is the meta-line about the case's actual argument, lifted from the body. The Critic flagged the second quote as candidate-for-cut and the Copywriter agreed in spirit; left in place because removing it is a structural call for the next composer round, not a design-system decision.
+- **InsightCallout** ×2 — first one carries the "shift wasn't AI made the charts; the shift was iterating at conversation speed" reframe inside the approach section; second one is the explicit outcome-update TODO at the end (composer left this in deliberately as a placeholder for a future revision once leadership acts on the open questions).
+- **DarkBand** — replaces the in-body Placeholder from the polished draft. Carries a side-by-side figure: tagged Miro board (before) next to two of the cleanest views from the final HTML (bubble chart + category × role heatmap). Sits between the process-detail section and the "what the final piece looks like" section as the visual hinge.
+
+Components considered and skipped:
+
+- **ProcessTimeline** — would over-formalize the iteration. The "Brief, draft, push back, repeat" section is already structured as bulleted rounds; a timeline would compete with that prose.
+- **GPTConversation** / **SystemRulesExcerpt** / **ConversationStackFailure** / **InteractionModelComparison** / **RulesObservations** / **QuestionnaireTiers** — these are agetech-specific custom components. None of them apply to this case's content.
+
+## Specimen choice
+
+**pomegranate-split**
+
+Reason: carried forward from the polished draft frontmatter (composer proposed it: "clustered themes opening to reveal what's inside" — fits a synthesis case where the work is segmenting one body of pain into legible parts). The visual exists in the V4 mockups as the "Minimal" sample's watermark. Converted from slug to path format (`/images/specimen-pomegranate-split.jpg`) to match the convention used by `agetech.mdx` and `ferguson-cx.mdx`.
+
+The composer flagged a thistle/tangle motif as an alternative ("data-knot framing"). If you want a different specimen, change `specimen` in the MDX frontmatter.
+
+## Image assets referenced (TODO — Whitney to upload)
+
+- `/images/specimen-pomegranate-split.jpg` — cover specimen, set in frontmatter. Used by `CaseLayout.astro`. **Currently doesn't exist.** Upload before publishing or remove the frontmatter line to fall back to no specimen.
+- `/images/data-viz/miro-before.jpg` — DarkBand left figure. The "before" Miro board with 40 themed stickies tagged by category, severity, and frequency. Composer confirmed there's a Miro screenshot in `raw-case-material/Data-Viz/` though it isn't a JPG yet; you may already have the source.
+- `/images/data-viz/final-charts.jpg` — DarkBand right figure. Two views from the final interactive HTML deliverable: bubble chart of all 40 themes + category × role heatmap. Source is `raw-case-material/Data-Viz/retrospective-synth.html` — you'll want to screenshot the bubble chart and heatmap views and combine into a single JPG (or split into two figures if that reads cleaner).
+
+If `/images/data-viz/` doesn't exist yet, create it under `public/`.
+
+## Narrative content that didn't fit V4 vocabulary
+
+- **The interactive HTML deliverable itself.** The strongest possible "show, don't tell" move for this particular case would be embedding or linking to a live version of `retrospective-synth.html` — both the composer and copywriter flagged this. The V4 vocabulary doesn't have a component for "embedded live artifact" today. Left out of the MDX. Worth raising as a future capability: this case is the strongest argument so far for an iframe or hosted-static-asset slot under `/artifacts/<slug>/`.
+
+## Open questions for Whitney
+
+- **Status field.** Set to `'published'` per the design-system-applier spec. The polished draft was `'draft'`. The case still has live TODOs (Felisha's last name, the outcome-update InsightCallout). Flip back to `'draft'` before merge if you don't want it live until those are filled in.
+- **Felisha [LAST NAME — TODO]** appears three times: in `role`, `team`, and the body's second paragraph. Copywriter intentionally preserved the placeholder markup. Replace before merge.
+- **Outcome InsightCallout at the bottom.** The Critic recommended cutting this on the grounds that the prose paragraph just above it already does the same work. The Copywriter agreed but kept it because the call is structural, not copy. Keep, replace with a real outcome line once you have one, or delete — your call.
+- **Second PullQuote** ("Senior service designers don't have to choose..."). Same situation: Critic recommended replacing it with a Felisha quote or cutting it; left in because the call is structural.
+- **`status: 'published'` + missing images.** The DarkBand figures will 404 until the `/images/data-viz/` assets exist. The visual-director step (next in the chain) typically swaps missing-asset references for `<Placeholder />` components so the page builds cleanly during preview. If you want to skip that step and ship straight, upload the images first, or temporarily comment out the DarkBand block.
+- **Work page card.** Adding this case to `src/pages/work.astro` is a separate manual edit (per the site repo's CLAUDE.md). Not done here.

--- a/src/content/cases/data-viz.mdx
+++ b/src/content/cases/data-viz.mdx
@@ -1,0 +1,116 @@
+---
+title: "Where pain lives <em>in our projects.</em>"
+client: 'Harmonic Design (internal)'
+year: 2026
+role: 'Service Designer & analysis lead (with Felisha [LAST NAME — TODO] on synthesis)'
+team: 'Whitney Masulis with Felisha [LAST NAME — TODO]; 25 studio members participating in the rating exercise'
+timeline: 'Spring 2026'
+tags:
+  - 'Service Design'
+  - 'Internal Operations'
+  - 'AI Prototyping'
+  - 'Synthesis'
+  - 'Data Visualization'
+summary: "An internal Harmonic retrospective synthesis where I used agentic AI as a working business analyst, feeding it the studio's own retro data and pushing it through enough rounds to produce a presentation leadership could actually act on."
+specimen: '/images/specimen-pomegranate-split.jpg'
+slug: 'data-viz'
+status: 'published'
+---
+import StatRow from '../../components/StatRow.astro';
+import PullQuote from '../../components/PullQuote.astro';
+import InsightCallout from '../../components/InsightCallout.astro';
+import BotanicalDivider from '../../components/BotanicalDivider.astro';
+import DarkBand from '../../components/DarkBand.astro';
+
+<StatRow variant="dark" stats={[
+  { value: '821', label: 'Ratings collected from 25 studio members' },
+  { value: '40', label: 'Themes across 9 categories distilled from project retros' },
+  { value: '7', label: 'Critical themes surfaced as both severe and frequent' },
+  { value: '1', label: 'Service designer doing analysis a business analyst usually does' },
+]} />
+
+## A studio's worth of retros, <em>and nothing changing because of them.</em>
+
+Harmonic Design, the firm I work at, runs retros at the end of every engagement. The retros happen. The stickies get written. People say the right things in the room. Then the next project starts and the same problems show up again. The retros are not the problem; the gap between retro and change is.
+
+I worked with Felisha [LAST NAME — TODO] to close that gap. We combed through the Miro boards from across our project history, pulled in transcripts where we had them, and interviewed people about what specific stickies meant when the language was ambiguous. We grouped what we found into 40 themes across 9 categories of work. Then we asked the whole studio to rate every theme on two scales: severity (1–4) and frequency (1–7), with a "does not apply" option so people weren't forced to invent a number for a kind of pain they'd never encountered.
+
+That much was conventional service design synthesis: surfacing, clustering, getting the team to weigh in. The interesting part started after the votes were in.
+
+<BotanicalDivider />
+
+## What I did differently: <em>treating agentic AI as a working business analyst.</em>
+
+Twenty-five people times forty themes times two scales is 2,000 possible cells. We got 821 actual ratings back, with the rest being "does not apply" or themes a particular role never reached. That's a real dataset, uneven across roles and with missingness that means something. It deserved real statistical handling.
+
+I am not a statistician. The version of me from two years ago would have built a pivot table in Google Sheets, eyeballed the top of the list, and called it a workshop input. That would have answered the loudest question (what scored highest combined) and missed the more interesting ones (which themes are severe but rare, where do junior and senior staff disagree, which clusters of themes look like one underlying problem with different surface symptoms).
+
+So I gave the data to Claude Code in a project folder, briefed it like I'd brief an analyst, and asked it to produce an interactive HTML site rather than a static deck.
+
+<PullQuote attribution="from my brief to Claude">
+  Audience is leadership. Use whatever charts and structure best answer those questions. End with discussion questions, not conclusions. Don't fabricate data. Show me what you compute and where it comes from. When you pick a visualization, briefly explain why you chose it.
+</PullQuote>
+
+The last sentence was the one that mattered. Asking the model to justify each visualization gave me something to push back against. It also gave me a running tutorial on what shape of chart fits what shape of question, which I'm now better at than I was before this project.
+
+<InsightCallout>
+  The shift wasn't "AI made the charts." The shift was that I could ask the kind of questions a business analyst would ask of this data, and iterate on them at conversation speed, without having to learn the statistical scaffolding first. The judgment about what the patterns *meant* still sat with me.
+</InsightCallout>
+
+## Brief, draft, push back, repeat. <em>Six or seven rounds, not one.</em>
+
+The first draft had the right data and the wrong shape. The bubble chart of all 40 themes was readable, but the "critical few" cut was too tidy: it implied a cleaner threshold than the data supported. I asked Claude to look again at the items just outside the cutoff. It surfaced a theme ("methodology baked in by sales before assessment") with the dataset's highest severity score that had landed just under the frequency threshold. That theme became its own callout in the final deliverable, and one of the open questions for leadership at the end.
+
+A few of the rounds that mattered:
+
+- **Push on grouping.** The model proposed four clusters of themes. One of them ("lead capacity") didn't fit with the others, and the takeaway language papered over that fact. I asked it to either justify the cluster or treat the outlier honestly. It chose honesty: the final deck has three patterns plus one "stubborn outlier" called out as a structural decision rather than a process to redesign.
+- **Push on language.** Early drafts used the theme codes (RE3, CE2, TD1) in narrative copy, which read as insider shorthand. I asked Claude to spell each theme out in plain language wherever it appeared in prose, and to keep the codes only as visual tags on the cards. That's the kind of edit a copywriter would make on draft three; I made it on draft two by asking.
+- **Push on tone.** A pass through the recommendations section came back too prescriptive: too many "we will" statements aimed at a leadership audience that hadn't been in the room for the analysis. I asked Claude to convert the strongest claims into questions for discussion, and to preserve only the recommendations that the data actually supported. The final section is named "Open questions for leadership," not "Recommended next steps."
+
+I also asked the model to add views I hadn't initially briefed it to produce: a category × role heatmap that shows where junior and senior staff diverge, a "frequent papercuts" cut for the low-severity-high-frequency zone, and a sortable rank of borderline themes. Each of those took about one prompt and one round of refinement. None of them would have made it into a version of the deck I built by hand inside the time we had.
+
+<DarkBand label="Before · After">
+  <h2>From tagged stickies <em>to a deck leadership can read in one sitting.</em></h2>
+  <p class="case-darkband-intro">On the left, the Miro board where the 40 themes were tagged by category, severity, and frequency: the raw material we handed to the analyst. On the right, two of the cleanest views from the final interactive HTML — the bubble chart of all 40 themes, and the category × role heatmap that surfaced where junior and senior staff diverged.</p>
+
+  <div class="case-darkband-figures">
+    <figure class="case-darkband-figure">
+      <img src="/images/data-viz/miro-before.jpg" alt="Miro board with 40 themed stickies tagged by category, severity rating, and frequency rating: the 'before' state of the synthesis." />
+      <figcaption class="case-darkband-figure-caption">Fig. 01 · Tagged Miro board, pre-analysis</figcaption>
+    </figure>
+    <figure class="case-darkband-figure">
+      <img src="/images/data-viz/final-charts.jpg" alt="Two views from the final interactive HTML deliverable: a bubble chart of all 40 themes plotted by severity and frequency, and a category-by-role heatmap." />
+      <figcaption class="case-darkband-figure-caption">Fig. 02 · Final HTML, bubble + heatmap</figcaption>
+    </figure>
+  </div>
+</DarkBand>
+
+## What the final piece looks like
+
+The output is an interactive HTML site titled *Where Pain Lives*. It is structured the way a leadership presentation should be structured: the landscape first (all 40 themes plotted), then the critical few (filtered to severe and frequent), then patterns (the clusters that read as the same underlying problem), then cuts by seniority and by category, then what we're explicitly not chasing, then a recommendations section honestly named as three streams plus one structural decision, and finally open questions for leadership rather than a hard close.
+
+It is in Harmonic's brand colors and typefaces. It has hoverable bubbles, sortable lists, and visual signals (the "Fix Now" zone is shaded; outliers are flagged in their own cards). It opens with a panel that explains the rating scales and what blanks mean, because half of leadership wasn't in the room when the scales were set.
+
+I did not write the HTML. I wrote the brief, made the synthesis judgments, sharpened the language, and decided what to cut. The model did the analysis, the visualization choices, and the layout. That division of labor is the point.
+
+<PullQuote attribution="What this case is actually about">
+  Senior service designers don't have to choose between "do the synthesis myself with the tools I know" and "hand it to an analyst." There's a third option now, and the craft is in knowing how to brief it and where to push back.
+</PullQuote>
+
+## What I'm taking from this
+
+A few things I want to do differently the next time I run this kind of synthesis with a working analyst in the loop:
+
+- **Brief the questions, not the chart types.** Every time I specified a visualization upfront, I got a worse output than when I described what I wanted to learn and let the model pick. The shapes of charts I'd never reached for (a category × role heatmap, in particular) outperformed the shapes I would have defaulted to.
+- **Verify the math when something surprises you.** When the model said something I didn't expect, I asked to see the calculation. Twice it caught its own arithmetic; once I caught a pattern that was real but more nuanced than the takeaway implied.
+- **Stop when it tells the story, not when it's perfect.** I could have iterated on the deck for another week. The marginal return after round six was very small. The version we presented was the version where leadership could read it once and have an opinion.
+
+## What I'm still thinking about
+
+The retro process at Harmonic was not broken. The synthesis-to-action gap was. This deliverable is one half of closing that gap; whether anything actually changes depends on what leadership does with the open questions at the end. I'll know in a quarter or two whether the streams of work named in the recommendations get owned by anyone, or whether the deck joins the stack of well-made artifacts that don't move the studio. That's the honest version of an outcome statement for an internal piece. TODO: report the follow-up once we have one.
+
+The other thing I'm still thinking about: how much of what I just did is portable to client work. The same rough pattern (a tagged synthesis deliverable feeding an agentic-AI analyst that produces an interactive output) could shorten the back half of a research engagement substantially. The constraints there are different (client data, NDA, audience appetite for "an AI made the charts"), but the underlying move scales.
+
+<InsightCallout label="Outcome update — pending">
+  TODO: outcome update once leadership has acted on (or quietly ignored) the open questions. Honest result either way.
+</InsightCallout>

--- a/src/content/cases/data-viz.mdx
+++ b/src/content/cases/data-viz.mdx
@@ -21,6 +21,7 @@ import PullQuote from '../../components/PullQuote.astro';
 import InsightCallout from '../../components/InsightCallout.astro';
 import BotanicalDivider from '../../components/BotanicalDivider.astro';
 import DarkBand from '../../components/DarkBand.astro';
+import Placeholder from '../../components/Placeholder.astro';
 
 <StatRow variant="dark" stats={[
   { value: '821', label: 'Ratings collected from 25 studio members' },
@@ -29,11 +30,35 @@ import DarkBand from '../../components/DarkBand.astro';
   { value: '1', label: 'Service designer doing analysis a business analyst usually does' },
 ]} />
 
+<Placeholder
+  kind="section"
+  size="block"
+  ask="One sentence (or short InsightCallout) acknowledging that the numbers and theme labels above are synthetic; the method and the iteration story are the real thing"
+  why="Critic flagged: the StatRow, the seven critical themes, and the outlier story are presented as real findings. If a hiring manager realizes mid-read (or in interview) that they're synthetic, credibility erodes. Disclosed up front, the rigor reads as method rather than headline numbers."
+  alternatives={[
+    "Place the disclosure at the head of 'What the final piece looks like' instead of here",
+    "Caption-only mention on the DarkBand figures (Critic specifically said this is too quiet)"
+  ]}
+  source="critic-flag"
+/>
+
 ## A studio's worth of retros, <em>and nothing changing because of them.</em>
 
 Harmonic Design, the firm I work at, runs retros at the end of every engagement. The retros happen. The stickies get written. People say the right things in the room. Then the next project starts and the same problems show up again. The retros are not the problem; the gap between retro and change is.
 
 I worked with Felisha [LAST NAME — TODO] to close that gap. We combed through the Miro boards from across our project history, pulled in transcripts where we had them, and interviewed people about what specific stickies meant when the language was ambiguous. We grouped what we found into 40 themes across 9 categories of work. Then we asked the whole studio to rate every theme on two scales: severity (1–4) and frequency (1–7), with a "does not apply" option so people weren't forced to invent a number for a kind of pain they'd never encountered.
+
+<Placeholder
+  kind="section"
+  size="block"
+  ask="One or two concrete lines distinguishing what Felisha specifically did upstream from what Whitney specifically did, before the Claude work began"
+  why="Critic flagged: Felisha appears in role/team and one body sentence, then disappears. As written, a reader can't tell whether Whitney led the qualitative synthesis with Felisha as partner or vice versa — which undersells Whitney's distinct upstream contribution. The case-interviewer round the composer requested is the right vehicle for surfacing this."
+  alternatives={[
+    "A single sentence naming Felisha's specific contribution if a full reshape of the paragraph isn't in scope",
+    "Resolve via Felisha's last name + role tightening in frontmatter only, leaving body as is (weakest option)"
+  ]}
+  source="critic-flag"
+/>
 
 That much was conventional service design synthesis: surfacing, clustering, getting the team to weigh in. The interesting part started after the votes were in.
 
@@ -97,6 +122,18 @@ I did not write the HTML. I wrote the brief, made the synthesis judgments, sharp
   Senior service designers don't have to choose between "do the synthesis myself with the tools I know" and "hand it to an analyst." There's a third option now, and the craft is in knowing how to brief it and where to push back.
 </PullQuote>
 
+<Placeholder
+  kind="section"
+  size="block"
+  ask="A short paragraph naming the internal politics and the act of moving the firm into agentic AI: how partners feel about 'AI did the analysis,' the rough economics (what a billable analyst would have cost / hours saved), and who at Harmonic owns whether the open questions become a workstream"
+  why="Critic flagged: this is an internal piece at a service-design firm where one designer is bringing agentic AI into synthesis for the first time. As written, the case reads as methodology. With the organizational layer, it becomes a leadership-of-change-inside-a-firm case — the senior-level claim Whitney is positioning for."
+  alternatives={[
+    "A tighter version: one sentence naming the political stakes without the economics",
+    "Two sentences: one on the politics, one on whose call the open-questions workstream is"
+  ]}
+  source="critic-flag"
+/>
+
 ## What I'm taking from this
 
 A few things I want to do differently the next time I run this kind of synthesis with a working analyst in the loop:
@@ -114,3 +151,30 @@ The other thing I'm still thinking about: how much of what I just did is portabl
 <InsightCallout label="Outcome update — pending">
   TODO: outcome update once leadership has acted on (or quietly ignored) the open questions. Honest result either way.
 </InsightCallout>
+
+## What I need from you
+
+This section is scaffolding from the visual-director agent. Delete it before publishing.
+
+### Images (3)
+
+- **Cover specimen** — `/images/specimen-pomegranate-split.jpg`. Referenced in frontmatter; doesn't exist yet. *Where:* `CaseLayout.astro` reads it from frontmatter for the case header. *Source:* human-capture (or pull from the V4 mockups, where the pomegranate-split lives as the "Minimal" sample's watermark). *Alternative:* remove the `specimen:` line to fall back to no specimen, or swap to a thistle/tangle motif (composer flagged "data-knot framing" as a viable alternate).
+- **DarkBand left figure** — `/images/data-viz/miro-before.jpg`. The tagged Miro board (40 stickies categorized + severity/frequency tagged): the "before" state of the synthesis. *Where:* the existing `<DarkBand>` block already references this path; will 404 in preview until uploaded. *Source:* `raw-case-material/Data-Viz/` per the applier handoff (a Miro screenshot is in the raw folder but not yet a JPG). *Alternative:* a blurred/cropped Miro export to anonymize specific theme labels if the synthetic-data disclosure (see Sections below) doesn't make full visibility comfortable.
+- **DarkBand right figure** — `/images/data-viz/final-charts.jpg`. Two views from the final HTML deliverable: bubble chart of all 40 themes plus the category × role heatmap. *Where:* same DarkBand block, right slot. *Source:* screenshot the live `retrospective-synth.html` and combine. *Alternative:* split into two separate figures inside the DarkBand if a single composite reads cluttered; or substitute a short looping screen recording of the interactive HTML in use (hovering bubbles, sorting the rank list).
+
+### Pull quotes (1)
+
+- **Felisha line to replace the second PullQuote** — the existing PullQuote at the close of "What the final piece looks like" ("Senior service designers don't have to choose...") is the writer stating the moral. Critic flagged it as a tell; Copywriter agreed the call is structural. *Where:* same slot, replacing the current quote. *Source:* a line from Felisha about what the AI-assisted method changed for her, or a moment from the interview round where Claude got something wrong and Whitney caught it. *Alternative:* cut the PullQuote entirely and let the body land the point — the "I did not write the HTML / The model did the analysis" passage two paragraphs above is already doing that work.
+
+### Sections to add (per critic) (3)
+
+- **Synthetic-data disclosure** — *(Placeholder inserted under the StatRow.)* Critic: "Numbers and theme labels here are synthetic; the method and the iteration story are real." One sentence is enough; lift it out of caption-only territory into body. *Where:* under the StatRow, or at the head of "What the final piece looks like."
+- **Felisha's contribution distinguished from Whitney's** — *(Placeholder inserted in the "A studio's worth of retros" section.)* Critic: "one or two concrete lines on what Felisha specifically did and what Whitney specifically did upstream of the Claude work." *Where:* the second paragraph of "A studio's worth of retros..." where Felisha is currently named once.
+- **Organizational stakes** — *(Placeholder inserted after the second PullQuote.)* Critic: "a short paragraph after the 'third option now' pull quote naming the internal politics and the act of moving the firm." Should land the political stakes, rough economics (cost/time of a billable analyst), and who has decision rights on the open-questions workstream.
+
+### Other content TODOs (not gaps I can placeholder, but flag for the same pass)
+
+- **Felisha [LAST NAME — TODO]** appears three times: `role`, `team`, and the second body paragraph. Replace before merge.
+- **Closing `<InsightCallout label="Outcome update — pending">`** — Critic recommended cutting on the grounds the prose paragraph just above it already does this work; Copywriter agreed but left it as a structural call. Keep, replace with a real outcome line once leadership has acted, or delete.
+- **Doubled thesis** (Critic issue #1, High) — synthesis-to-action gap vs. new-shape-of-senior-synthesis-with-an-agentic-analyst. This is a structural rewrite for the next composer round, not something a placeholder fixes; flagging here so it doesn't get lost.
+- **`status: 'published'`** is set in frontmatter while live TODOs remain. Flip back to `'draft'` until they're filled, or push through if shipping immediately.


### PR DESCRIPTION
Applies V4 portfolio design system to the polished draft from Agent-Land PR #24 (https://github.com/whitneyesque/Agent-Land/pull/24). Handoff notes (component choices, image-asset TODOs, open questions) are in the HTML comment at the bottom of src/content/cases/data-viz.mdx. To preview locally: cd ~/dev/whitneyesque.github.io && git fetch origin && git checkout design-system/data-viz-29 && npm install && npm run dev — then open http://localhost:4321/cases/data-viz