### PR TITLE
agetech: CaregivingPrototypeShowcase component

### DIFF
--- a/src/components/CaregivingPrototypeShowcase.astro
+++ b/src/components/CaregivingPrototypeShowcase.astro
@@ -1,0 +1,985 @@
+---
+/**
+ * CaregivingPrototypeShowcase.astro — V4
+ *
+ * Three-up gallery recreating the v2 lo-fi wireframes from the agetech case
+ * (Situational Guidance / Dashboard / Care Forecast) in the portfolio palette.
+ *
+ * Each panel is a brand-styled illustration of a v2 mode's interface — not a
+ * screenshot of the source artifact and not a working UI. The intent is to
+ * give the reader a concrete look at what "modes that produce artifacts"
+ * actually meant, after a lot of prose has had to carry that claim alone.
+ *
+ * Anonymization:
+ * - Source product wordmark replaced with a neutral dot mark + "Care Guide"
+ * - Person names replaced with role labels (the caregiver / the care recipient)
+ * - The $122,000 forecast number is preserved — useful evidence, not identifying
+ *
+ * No JavaScript. Pure HTML + scoped CSS. Responsive: 3-up on desktop,
+ * stacked on mobile.
+ */
+---
+
+<figure class="cps">
+  <figcaption class="cps-lede">
+    Three of the v2 modes, each producing a different kind of artifact. Lo-fi
+    by design — these are illustrations of an interface, not a working product.
+  </figcaption>
+
+  <div class="cps-grid">
+
+    <!-- ============ Panel 1: Situational Guidance ============ -->
+    <div class="cps-panel">
+      <span class="cps-eyebrow">Mode 01 · Situational Guidance</span>
+      <div class="cps-frame" role="img" aria-label="Recreation of the Situational Guidance mode: a chat-style interface with suggested prompts and a sidebar of past discussions.">
+        <div class="cps-chrome">
+          <span class="cps-dot"></span>
+          <span class="cps-dot"></span>
+          <span class="cps-dot"></span>
+          <span class="cps-mark"><span class="cps-mark-glyph"></span>Care Guide</span>
+        </div>
+
+        <div class="cps-body cps-body--chat">
+          <aside class="cps-nav" aria-hidden="true">
+            <span class="cps-nav-item">Dashboard</span>
+            <span class="cps-nav-item">Forecast</span>
+            <span class="cps-nav-item cps-nav-item--active">Ask Care Guide</span>
+            <span class="cps-nav-divider"></span>
+            <span class="cps-nav-item">My profile</span>
+            <span class="cps-nav-item">Care recipient</span>
+            <span class="cps-nav-item">Settings</span>
+          </aside>
+
+          <section class="cps-main">
+            <h4 class="cps-h">Ask Care Guide</h4>
+            <div class="cps-card cps-card--chat">
+              <div class="cps-edit">Edit preferences</div>
+              <div class="cps-empty">
+                <span class="cps-empty-glyph" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 3l2.6 5.5 6 .8-4.4 4.1 1.1 6-5.3-2.9L6.7 19.4l1.1-6L3.4 9.3l6-.8L12 3z"/></svg>
+                </span>
+                <p class="cps-empty-title">Caregiving guidance personalized for you</p>
+                <p class="cps-empty-sub">Not sure where to start? You can ask about…</p>
+                <div class="cps-prompts">
+                  <span class="cps-prompt">Understanding memory changes</span>
+                  <span class="cps-prompt">Setting up scam protection</span>
+                  <span class="cps-prompt">Prepping for cognitive evaluation</span>
+                  <span class="cps-prompt">Building a support network</span>
+                  <span class="cps-prompt">Talking to your employer</span>
+                  <span class="cps-prompt cps-prompt--more">+ More</span>
+                </div>
+              </div>
+              <div class="cps-input">
+                <span class="cps-input-text">Start the conversation…</span>
+                <span class="cps-input-send" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M3 11l18-8-8 18-2-7-8-3z"/></svg>
+                </span>
+              </div>
+            </div>
+          </section>
+
+          <aside class="cps-side" aria-hidden="true">
+            <p class="cps-side-h">Past discussions</p>
+            <span class="cps-side-row">Tips on medication management</span>
+            <span class="cps-side-row">Future care planning</span>
+            <span class="cps-side-row">Medications &amp; side effects</span>
+            <span class="cps-side-row">Managing caregiver stress</span>
+            <span class="cps-side-divider"></span>
+            <span class="cps-side-pill">Care recipient profile</span>
+            <span class="cps-side-pill">Medical conditions</span>
+            <span class="cps-side-pill">Medications</span>
+            <div class="cps-disclaimer">
+              <p class="cps-disclaimer-h">About situational guidance</p>
+              <p class="cps-disclaimer-body">Personalized to your caregiver profile. Not medical advice — for medical decisions, consult a doctor. In an emergency, call 911.</p>
+            </div>
+          </aside>
+        </div>
+      </div>
+      <p class="cps-cap"><em>Artifact: a personalized answer to a caregiver's specific question.</em></p>
+    </div>
+
+    <!-- ============ Panel 2: Dashboard ============ -->
+    <div class="cps-panel">
+      <span class="cps-eyebrow">Mode 02 · Dashboard</span>
+      <div class="cps-frame" role="img" aria-label="Recreation of the Dashboard mode: top-priority action items, a forecast summary, and caregiver and care recipient profile cards.">
+        <div class="cps-chrome">
+          <span class="cps-dot"></span>
+          <span class="cps-dot"></span>
+          <span class="cps-dot"></span>
+          <span class="cps-mark"><span class="cps-mark-glyph"></span>Care Guide</span>
+        </div>
+
+        <div class="cps-body cps-body--dash">
+          <aside class="cps-nav" aria-hidden="true">
+            <span class="cps-nav-item cps-nav-item--active">Dashboard</span>
+            <span class="cps-nav-item">Forecast</span>
+            <span class="cps-nav-item">Ask Care Guide</span>
+            <span class="cps-nav-divider"></span>
+            <span class="cps-nav-item">My profile</span>
+            <span class="cps-nav-item">Care recipient</span>
+            <span class="cps-nav-item">Settings</span>
+          </aside>
+
+          <section class="cps-main">
+            <h4 class="cps-h">Dashboard</h4>
+
+            <div class="cps-cols">
+              <div class="cps-card">
+                <p class="cps-card-h">Action items</p>
+                <p class="cps-card-sub">Top priority</p>
+                <ul class="cps-checks">
+                  <li><span class="cps-check"></span>Install call-blocking and scam protection</li>
+                  <li><span class="cps-check"></span>Schedule cognitive evaluation</li>
+                  <li><span class="cps-check"></span>Arrange physical therapy for knee strength</li>
+                </ul>
+                <span class="cps-link">View full list</span>
+              </div>
+
+              <div class="cps-card">
+                <p class="cps-card-h">Caregiver</p>
+                <div class="cps-profile">
+                  <span class="cps-avatar" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.4"><circle cx="12" cy="9" r="3.5"/><path d="M5 20c1.5-3.5 4-5 7-5s5.5 1.5 7 5"/></svg>
+                  </span>
+                  <div>
+                    <p class="cps-name">The caregiver</p>
+                    <p class="cps-role">Adult child, primary caregiver</p>
+                  </div>
+                  <span class="cps-meter">
+                    <span class="cps-meter-l">Profile<br/>complete</span>
+                    <span class="cps-meter-v">100%</span>
+                    <span class="cps-meter-bar"><span style="width:100%"></span></span>
+                  </span>
+                </div>
+                <p class="cps-meta">Current caregiving tasks: <strong>20–40 hrs/week</strong></p>
+                <span class="cps-link">View full profile</span>
+              </div>
+            </div>
+
+            <div class="cps-cols">
+              <div class="cps-card">
+                <p class="cps-card-h">Forecast summary</p>
+                <div class="cps-fc">
+                  <div class="cps-fc-num">
+                    <p class="cps-fc-label">Forecast<br/>completeness</p>
+                    <p class="cps-fc-pct">80%</p>
+                    <span class="cps-meter-bar"><span style="width:80%"></span></span>
+                  </div>
+                  <div class="cps-fc-list">
+                    <p class="cps-card-sub">Care outlook</p>
+                    <ul class="cps-bullets">
+                      <li>Mobility support needs may gradually increase</li>
+                      <li>Memory changes may require structured oversight</li>
+                      <li>Family involvement supports staying at home</li>
+                    </ul>
+                  </div>
+                </div>
+                <span class="cps-link">View full forecast</span>
+              </div>
+
+              <div class="cps-card">
+                <p class="cps-card-h">Care recipient</p>
+                <div class="cps-profile">
+                  <span class="cps-avatar" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.4"><circle cx="12" cy="9" r="3.5"/><path d="M5 20c1.5-3.5 4-5 7-5s5.5 1.5 7 5"/></svg>
+                  </span>
+                  <div>
+                    <p class="cps-name">The care recipient</p>
+                    <p class="cps-role">Parent, age 82</p>
+                  </div>
+                  <span class="cps-meter">
+                    <span class="cps-meter-l">Profile<br/>complete</span>
+                    <span class="cps-meter-v">50%</span>
+                    <span class="cps-meter-bar"><span style="width:50%"></span></span>
+                  </span>
+                </div>
+                <p class="cps-meta">Lives with adult child, multigenerational household</p>
+                <span class="cps-link">View full profile</span>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+      <p class="cps-cap"><em>Artifact: prioritized action items, drawn from the caregiver and care-recipient profiles.</em></p>
+    </div>
+
+    <!-- ============ Panel 3: Care Forecast ============ -->
+    <div class="cps-panel">
+      <span class="cps-eyebrow">Mode 03 · Care Forecast</span>
+      <div class="cps-frame" role="img" aria-label="Recreation of the Care Forecast mode: time-range tabs, watch-out clinical guidance, recommended action items, and a five-year financial projection totaling $122,000.">
+        <div class="cps-chrome">
+          <span class="cps-dot"></span>
+          <span class="cps-dot"></span>
+          <span class="cps-dot"></span>
+          <span class="cps-mark"><span class="cps-mark-glyph"></span>Care Guide</span>
+        </div>
+
+        <div class="cps-body cps-body--forecast">
+          <aside class="cps-nav" aria-hidden="true">
+            <span class="cps-nav-item">Dashboard</span>
+            <span class="cps-nav-item cps-nav-item--active">Forecast</span>
+            <span class="cps-nav-item">Ask Care Guide</span>
+            <span class="cps-nav-divider"></span>
+            <span class="cps-nav-item">My profile</span>
+            <span class="cps-nav-item">Care recipient</span>
+            <span class="cps-nav-item">Settings</span>
+          </aside>
+
+          <section class="cps-main">
+            <h4 class="cps-h">Care forecast</h4>
+
+            <div class="cps-tabs" role="tablist" aria-label="Forecast time range">
+              <span class="cps-tab cps-tab--active">Next 0–3 months</span>
+              <span class="cps-tab">Next 3–12 months</span>
+              <span class="cps-tab">Next 1–3 years</span>
+              <span class="cps-tab">Next 4+ years</span>
+            </div>
+            <p class="cps-tab-note">Based on the most recent profile and forecast questionnaire. Reminder: this is planning guidance, not a prediction.</p>
+
+            <div class="cps-cols">
+              <div class="cps-card cps-card--tight">
+                <p class="cps-card-h">Watch out for</p>
+                <ul class="cps-bullets">
+                  <li>Increased unsteadiness or near-falls</li>
+                  <li>More frequent repeated questions</li>
+                  <li>Sharing personal information with phone callers</li>
+                  <li>Withdrawing from daily activities</li>
+                </ul>
+              </div>
+              <div class="cps-card cps-card--tight">
+                <p class="cps-card-h">Recommended action items</p>
+                <ul class="cps-checks">
+                  <li><span class="cps-check"></span>Install call-blocking and scam protection</li>
+                  <li><span class="cps-check"></span>Schedule cognitive evaluation</li>
+                  <li><span class="cps-check"></span>Arrange physical therapy</li>
+                  <li><span class="cps-check"></span>Review home fall-prevention plan</li>
+                </ul>
+              </div>
+            </div>
+
+            <div class="cps-card cps-fin">
+              <p class="cps-card-h">Financial forecasting</p>
+              <div class="cps-fin-grid">
+                <div class="cps-fin-total">
+                  <p class="cps-card-sub">Potential care costs · next 5 years</p>
+                  <p class="cps-fin-num">$122,000</p>
+                  <p class="cps-fin-foot">Caregivers in similar situations spend an average of $7,000 out-of-pocket per year.</p>
+                </div>
+                <ul class="cps-fin-years">
+                  <li><span>Year 1</span><span>$8,500</span></li>
+                  <li><span>Year 2</span><span>$12,500</span></li>
+                  <li><span>Year 3</span><span>$20,000</span></li>
+                  <li><span>Year 4</span><span>$32,500</span></li>
+                  <li><span>Year 5</span><span>$48,500</span></li>
+                </ul>
+                <ul class="cps-fin-incl">
+                  <li>Part-time companion care, 5–10 hrs/week</li>
+                  <li>Physical therapy and specialist copays</li>
+                  <li>Medication copays and monitoring visits</li>
+                  <li>Home safety upgrades and equipment</li>
+                  <li>Increased supervision as memory changes progress</li>
+                </ul>
+              </div>
+            </div>
+          </section>
+
+          <aside class="cps-side cps-side--forecast" aria-hidden="true">
+            <p class="cps-side-h">About this forecast</p>
+            <p class="cps-side-body">A best-guess projection based on the caregiver profile, care-recipient profile, and forecast questionnaire. Not medical advice.</p>
+            <span class="cps-side-cta">Forecast questionnaire</span>
+            <span class="cps-side-cta">Learn about forecasting</span>
+          </aside>
+        </div>
+      </div>
+      <p class="cps-cap"><em>Artifact: a multi-year care projection, with clinical watch-outs and a cost estimate.</em></p>
+    </div>
+
+  </div>
+</figure>
+
+<style>
+  .cps {
+    margin: 3rem 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .cps-lede {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-style: italic;
+    font-size: 16px;
+    line-height: 1.5;
+    color: var(--charcoal-mid, #4A443D);
+    max-width: 60ch;
+    margin: 0;
+  }
+
+  .cps-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.5rem;
+    align-items: start;
+  }
+
+  .cps-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-width: 0;
+  }
+
+  .cps-eyebrow {
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 10px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--gold-text, #8A6820);
+    font-weight: 700;
+  }
+
+  .cps-frame {
+    background: var(--cream, #F4EDE4);
+    border: 1px solid var(--cream-deep, #EBE1D4);
+    border-radius: 6px;
+    overflow: hidden;
+    box-shadow: 0 1px 0 rgba(42, 37, 32, 0.04), 0 6px 16px rgba(42, 37, 32, 0.06);
+    aspect-ratio: 4 / 3;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Browser chrome */
+  .cps-chrome {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 8px 12px;
+    background: var(--cream-deep, #EBE1D4);
+    border-bottom: 1px solid rgba(42, 37, 32, 0.08);
+  }
+  .cps-dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--charcoal-soft, #6B6560);
+    opacity: 0.45;
+  }
+  .cps-mark {
+    margin-left: 10px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--charcoal, #2A2520);
+    letter-spacing: 0.01em;
+  }
+  .cps-mark-glyph {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    background: var(--gold, #C8943E);
+    display: inline-block;
+  }
+
+  /* Body */
+  .cps-body {
+    flex: 1 1 auto;
+    display: grid;
+    background: var(--warm-white, #FAF7F3);
+    min-height: 0;
+    overflow: hidden;
+  }
+  .cps-body--chat,
+  .cps-body--dash,
+  .cps-body--forecast {
+    grid-template-columns: 70px 1fr 90px;
+  }
+  .cps-body--dash {
+    grid-template-columns: 70px 1fr;
+  }
+
+  /* Nav */
+  .cps-nav {
+    background: var(--cream, #F4EDE4);
+    border-right: 1px solid var(--cream-deep, #EBE1D4);
+    padding: 10px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    overflow: hidden;
+  }
+  .cps-nav-item {
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 7.5px;
+    letter-spacing: 0.06em;
+    color: var(--charcoal-soft, #6B6560);
+    padding: 4px 6px;
+    border-radius: 2px;
+    line-height: 1.3;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .cps-nav-item--active {
+    background: var(--gold-pale, #F0E4CC);
+    color: var(--gold-text, #8A6820);
+    font-weight: 700;
+  }
+  .cps-nav-divider {
+    height: 1px;
+    background: var(--cream-deep, #EBE1D4);
+    margin: 4px 0;
+  }
+
+  /* Main */
+  .cps-main {
+    padding: 12px 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-width: 0;
+    overflow: hidden;
+  }
+  .cps-h {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--charcoal, #2A2520);
+    margin: 0;
+    line-height: 1.2;
+  }
+
+  /* Card */
+  .cps-card {
+    background: var(--warm-white, #FAF7F3);
+    border: 1px solid var(--cream-deep, #EBE1D4);
+    border-radius: 4px;
+    padding: 10px 10px;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .cps-card--tight { padding: 8px 9px; gap: 4px; }
+  .cps-card-h {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--charcoal, #2A2520);
+    margin: 0;
+    line-height: 1.2;
+  }
+  .cps-card-sub {
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 7.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--charcoal-soft, #6B6560);
+    margin: 0;
+  }
+
+  .cps-cols {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .cps-checks {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .cps-checks li {
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 8.5px;
+    line-height: 1.3;
+    color: var(--charcoal-mid, #4A443D);
+    display: flex;
+    gap: 5px;
+    align-items: flex-start;
+  }
+  .cps-check {
+    flex: 0 0 auto;
+    width: 8px; height: 8px;
+    border: 1px solid var(--charcoal-soft, #6B6560);
+    border-radius: 1px;
+    margin-top: 2px;
+  }
+
+  .cps-bullets {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .cps-bullets li {
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 8.5px;
+    line-height: 1.3;
+    color: var(--charcoal-mid, #4A443D);
+    padding-left: 9px;
+    position: relative;
+  }
+  .cps-bullets li::before {
+    content: '';
+    position: absolute;
+    left: 2px; top: 6px;
+    width: 3px; height: 3px;
+    background: var(--gold, #C8943E);
+    border-radius: 50%;
+  }
+
+  .cps-link {
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 7.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--gold-text, #8A6820);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    margin-top: auto;
+    align-self: flex-start;
+  }
+
+  /* Profile */
+  .cps-profile {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 8px;
+    align-items: center;
+  }
+  .cps-avatar {
+    width: 28px; height: 28px;
+    border-radius: 50%;
+    background: var(--cream, #F4EDE4);
+    border: 1px solid var(--cream-deep, #EBE1D4);
+    color: var(--charcoal-soft, #6B6560);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .cps-name {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--charcoal, #2A2520);
+    margin: 0;
+    line-height: 1.2;
+  }
+  .cps-role {
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 8.5px;
+    color: var(--charcoal-soft, #6B6560);
+    margin: 1px 0 0 0;
+    line-height: 1.2;
+  }
+  .cps-meter {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    align-items: flex-end;
+    min-width: 50px;
+  }
+  .cps-meter-l {
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 6.5px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--charcoal-soft, #6B6560);
+    text-align: right;
+    line-height: 1.1;
+  }
+  .cps-meter-v {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--gold-text, #8A6820);
+    line-height: 1;
+  }
+  .cps-meter-bar {
+    width: 50px;
+    height: 3px;
+    background: var(--cream-deep, #EBE1D4);
+    border-radius: 2px;
+    overflow: hidden;
+    display: block;
+  }
+  .cps-meter-bar > span {
+    display: block;
+    height: 100%;
+    background: var(--gold, #C8943E);
+  }
+  .cps-meta {
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 8.5px;
+    color: var(--charcoal-mid, #4A443D);
+    margin: 0;
+    line-height: 1.3;
+  }
+  .cps-meta strong { color: var(--charcoal, #2A2520); font-weight: 700; }
+
+  /* Forecast summary card layout */
+  .cps-fc {
+    display: grid;
+    grid-template-columns: minmax(0, 88px) 1fr;
+    gap: 10px;
+    align-items: start;
+  }
+  .cps-fc-num {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    border-right: 1px solid var(--cream-deep, #EBE1D4);
+    padding-right: 8px;
+  }
+  .cps-fc-label {
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 7.5px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--charcoal-soft, #6B6560);
+    margin: 0;
+    line-height: 1.2;
+  }
+  .cps-fc-pct {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--gold-text, #8A6820);
+    margin: 0;
+    line-height: 1;
+  }
+
+  /* Chat panel specifics */
+  .cps-card--chat {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    position: relative;
+  }
+  .cps-edit {
+    align-self: flex-end;
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 7.5px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--gold-text, #8A6820);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .cps-empty {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 5px;
+    padding: 6px 4px;
+  }
+  .cps-empty-glyph {
+    color: var(--gold, #C8943E);
+    display: inline-flex;
+  }
+  .cps-empty-title {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--charcoal, #2A2520);
+    margin: 0;
+    line-height: 1.2;
+  }
+  .cps-empty-sub {
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 8.5px;
+    color: var(--charcoal-soft, #6B6560);
+    margin: 0;
+  }
+  .cps-prompts {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 4px;
+    width: 100%;
+    margin-top: 4px;
+  }
+  .cps-prompt {
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 7.5px;
+    line-height: 1.25;
+    color: var(--charcoal-mid, #4A443D);
+    background: var(--cream, #F4EDE4);
+    border: 1px solid var(--cream-deep, #EBE1D4);
+    border-radius: 3px;
+    padding: 5px 5px;
+    text-align: center;
+    min-height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .cps-prompt--more {
+    color: var(--gold-text, #8A6820);
+    font-weight: 700;
+  }
+  .cps-input {
+    margin-top: auto;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 8px;
+    border: 1px solid var(--cream-deep, #EBE1D4);
+    border-radius: 14px;
+    background: var(--cream, #F4EDE4);
+  }
+  .cps-input-text {
+    flex: 1 1 auto;
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-style: italic;
+    font-size: 8.5px;
+    color: var(--charcoal-soft, #6B6560);
+  }
+  .cps-input-send {
+    color: var(--gold-text, #8A6820);
+    display: inline-flex;
+  }
+
+  /* Sidebar (chat + forecast) */
+  .cps-side {
+    background: var(--cream, #F4EDE4);
+    border-left: 1px solid var(--cream-deep, #EBE1D4);
+    padding: 10px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    overflow: hidden;
+  }
+  .cps-side-h {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 9.5px;
+    font-weight: 700;
+    color: var(--charcoal, #2A2520);
+    margin: 0;
+    line-height: 1.2;
+  }
+  .cps-side-row {
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 7px;
+    color: var(--charcoal-mid, #4A443D);
+    line-height: 1.25;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .cps-side-divider {
+    height: 1px;
+    background: var(--cream-deep, #EBE1D4);
+    margin: 3px 0;
+  }
+  .cps-side-pill {
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 7px;
+    color: var(--charcoal-mid, #4A443D);
+    border: 1px solid var(--cream-deep, #EBE1D4);
+    background: var(--warm-white, #FAF7F3);
+    border-radius: 2px;
+    padding: 3px 5px;
+    line-height: 1.2;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .cps-disclaimer {
+    margin-top: auto;
+    background: var(--charcoal, #2A2520);
+    color: var(--cream, #F4EDE4);
+    padding: 6px 7px;
+    border-radius: 3px;
+  }
+  .cps-disclaimer-h {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 8.5px;
+    font-weight: 700;
+    color: var(--gold-light, #D4A85A);
+    margin: 0 0 2px 0;
+    line-height: 1.2;
+  }
+  .cps-disclaimer-body {
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 6.8px;
+    line-height: 1.3;
+    color: rgba(244, 237, 228, 0.85);
+    margin: 0;
+  }
+
+  /* Forecast tabs */
+  .cps-tabs {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 4px;
+  }
+  .cps-tab {
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 7px;
+    letter-spacing: 0.04em;
+    color: var(--charcoal-soft, #6B6560);
+    background: var(--warm-white, #FAF7F3);
+    border: 1px solid var(--cream-deep, #EBE1D4);
+    border-radius: 3px;
+    padding: 4px 4px;
+    text-align: center;
+    line-height: 1.2;
+  }
+  .cps-tab--active {
+    background: var(--gold-pale, #F0E4CC);
+    border-color: var(--gold, #C8943E);
+    color: var(--gold-text, #8A6820);
+    font-weight: 700;
+  }
+  .cps-tab-note {
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 8px;
+    font-style: italic;
+    color: var(--charcoal-soft, #6B6560);
+    margin: 0;
+    line-height: 1.3;
+  }
+
+  /* Financial block */
+  .cps-fin { gap: 8px; }
+  .cps-fin-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.85fr) minmax(0, 1fr);
+    gap: 8px;
+    align-items: start;
+  }
+  .cps-fin-total { display: flex; flex-direction: column; gap: 3px; }
+  .cps-fin-num {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--gold-text, #8A6820);
+    margin: 0;
+    line-height: 1;
+  }
+  .cps-fin-foot {
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 7.5px;
+    color: var(--charcoal-soft, #6B6560);
+    margin: 2px 0 0 0;
+    line-height: 1.3;
+    font-style: italic;
+  }
+  .cps-fin-years,
+  .cps-fin-incl {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .cps-fin-years li {
+    display: flex;
+    justify-content: space-between;
+    gap: 6px;
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 7.5px;
+    color: var(--charcoal-mid, #4A443D);
+    border-bottom: 1px dotted var(--cream-deep, #EBE1D4);
+    padding: 1px 0;
+  }
+  .cps-fin-years li span:last-child {
+    color: var(--charcoal, #2A2520);
+    font-weight: 700;
+  }
+  .cps-fin-incl li {
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 7.5px;
+    color: var(--charcoal-mid, #4A443D);
+    line-height: 1.3;
+    padding-left: 8px;
+    position: relative;
+  }
+  .cps-fin-incl li::before {
+    content: '';
+    position: absolute;
+    left: 2px; top: 5px;
+    width: 2.5px; height: 2.5px;
+    background: var(--charcoal-soft, #6B6560);
+    border-radius: 50%;
+  }
+
+  .cps-side--forecast {
+    border-left: 1px solid var(--cream-deep, #EBE1D4);
+  }
+  .cps-side-body {
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 7px;
+    color: var(--charcoal-mid, #4A443D);
+    line-height: 1.35;
+    margin: 0;
+  }
+  .cps-side-cta {
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 6.5px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--charcoal, #2A2520);
+    background: var(--warm-white, #FAF7F3);
+    border: 1px solid var(--cream-deep, #EBE1D4);
+    border-radius: 2px;
+    padding: 4px 5px;
+    text-align: center;
+    line-height: 1.2;
+  }
+
+  /* Caption */
+  .cps-cap {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-style: italic;
+    font-size: 13px;
+    color: var(--charcoal-mid, #4A443D);
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  /* ============ Tablet: 2-up ============ */
+  @media (max-width: 1080px) {
+    .cps-grid {
+      grid-template-columns: 1fr;
+      gap: 2rem;
+    }
+    .cps-frame {
+      aspect-ratio: 16 / 10;
+      max-width: 760px;
+    }
+  }
+
+  /* ============ Mobile ============ */
+  @media (max-width: 600px) {
+    .cps-frame {
+      aspect-ratio: auto;
+      min-height: 360px;
+    }
+    .cps-body--chat,
+    .cps-body--forecast {
+      grid-template-columns: 56px 1fr;
+    }
+    .cps-side { display: none; }
+    .cps-prompts { grid-template-columns: 1fr 1fr; }
+    .cps-fin-grid {
+      grid-template-columns: 1fr;
+    }
+    .cps-fin-total { border-right: 0; padding-right: 0; }
+    .cps-cols { grid-template-columns: 1fr; }
+    .cps-fc { grid-template-columns: 1fr; }
+    .cps-fc-num { border-right: 0; padding-right: 0; }
+  }
+</style>

--- a/src/content/cases/agetech.mdx
+++ b/src/content/cases/agetech.mdx
@@ -25,6 +25,7 @@ import RulesObservations from '../../components/RulesObservations.astro';
 import SystemRulesExcerpt from '../../components/SystemRulesExcerpt.astro';
 import ConversationStackFailure from '../../components/ConversationStackFailure.astro';
 import QuestionnaireTiers from '../../components/QuestionnaireTiers.astro';
+import CaregivingPrototypeShowcase from '../../components/CaregivingPrototypeShowcase.astro';
 
 <StatRow variant="dark" stats={[
   { value: '50M+', label: 'U.S. family caregivers' },
@@ -167,6 +168,8 @@ The v2 system wasn't a re-sequenced v1. It was a different interaction model.
 **v1 asked. v2 helped.**
 
 <InteractionModelComparison />
+
+<CaregivingPrototypeShowcase />
 
 The new version replaced the six-phase pipeline with eight task-shaped modes, each designed to deliver an actionable artifact within about ten minutes. The Dispatcher: triage what needs attention first. The Checkup: scan for gaps. The Planner: build a coordination system. The Money Map: model what care will cost. The Translator: build a doctor prep sheet or a hard message to a sibling. The Rehearsal Studio: practice a difficult conversation. The Family Sync: align everyone on the same picture. The Pressure Valve: process the emotional weight of a hard moment when nothing else can move yet.
 


### PR DESCRIPTION
## Summary

Adds a new Astro component that recreates the three v2 lo-fi wireframes (Situational Guidance / Dashboard / Care Forecast) in the portfolio palette. First time a reader of the agetech case actually sees what the v2 service interface looked like.

## What's in this PR

- New: `src/components/CaregivingPrototypeShowcase.astro` — 3-up branded recreation, responsive, no JS
- NOT placed in agetech.mdx in this PR. Whitney will place it after reviewing.

## Anonymization

- "CareStar" wordmark replaced with a neutral mark (small gold dot + "Care Guide")
- Person names replaced with role labels ("the caregiver", "the care recipient")
- "Ask CareStar" → "Ask Care Guide"; product references in disclaimer / chat prompt scrubbed
- $122,000 forecast figure preserved (useful evidence, not identifying)

## Recovery

Pre-existing main: `whitneyesque/whitneyesque.github.io@4225e7d4a51292ae297992590f009b977a49e0af`

## Test plan

- [ ] Open Cloudflare preview, verify the component renders standalone (e.g., on a test page)
- [ ] Confirm palette + typography match other portfolio components
- [ ] Confirm no "CareStar" or person names appear in rendered output
- [ ] Confirm responsive layout works mobile + desktop
- [ ] Decide where in agetech.mdx to place it (suggested: after `<InteractionModelComparison />` in "The redesign: from sequential interview to modal tool")