### PR TITLE
allied: RefundPlus actor-map diagram

### DIFF
--- a/src/components/RefundPlusActorMap.astro
+++ b/src/components/RefundPlusActorMap.astro
@@ -25,8 +25,9 @@
 
 <figure class="v4-rpam" aria-label="The four actor types in RefundPlus and the data and money flows between them">
   <header class="v4-rpam-scenario">
-    <span class="v4-rpam-scenario-label">The trigger</span>
+    <span class="v4-rpam-scenario-label">The setup</span>
     <p>A customer cancels a GAP product or another ancillary auto-loan add-on before the loan term ends. That cancellation owes the customer a refund — which has to move across all four actors below: requested by the lender, sourced from the provider, coordinated by Allied, and ultimately paid back through the lender.</p>
+    <p>At the start of the project, RefundPlus was running this whole flow as a manual, hand-stitched pilot for a few lender clients — spreadsheets, phone calls, one-off email handoffs between Allied operators and partner contacts. Federal rules had just begun requiring lenders to refund customers within thirty days in some states, and demand was already past what the manual process could absorb.</p>
   </header>
 
   <div class="v4-rpam-diagram" role="img"

--- a/src/components/RefundPlusActorMap.astro
+++ b/src/components/RefundPlusActorMap.astro
@@ -1,0 +1,473 @@
+---
+/**
+ * RefundPlusActorMap.astro — V4
+ *
+ * Four-actor system diagram for the Allied / RefundPlus case study.
+ *
+ * Shows the four actor types in the RefundPlus service (Lender, Dealer,
+ * Provider, Allied) arranged spatially with Allied at the center as the
+ * coordinator, and the dominant data + money flows labeled between them.
+ *
+ * Each actor is in a distinct portfolio-palette color so the reader can
+ * track who's who without re-reading labels:
+ *   - Allied    → charcoal (anchor / coordinator, the most prominent)
+ *   - Lender    → sage     (originator / source of the cancellation event)
+ *   - Dealer    → rust     (holds product data Allied needs to refund)
+ *   - Provider  → gold     (underwriter / cuts the check)
+ *   - Customer  → cream-deep neutral chip on the edge
+ *
+ * Pure HTML + scoped CSS + inline SVG, no JavaScript. On desktop the
+ * actors are laid out on a 3-column / 3-row grid with Allied in the
+ * middle; on mobile the layout reflows to a single column with arrows
+ * indicating direction of flow.
+ */
+---
+
+<figure class="v4-rpam" aria-label="The four actor types in RefundPlus and the data and money flows between them">
+  <div class="v4-rpam-diagram" role="img"
+       aria-label="Allied sits at the center coordinating between lender, dealer, and provider. Data flows from lender and dealer into Allied; Allied passes data to the provider. Money flows from the provider through Allied back to the lender, who pays the customer. A status portal makes the process visible to the lender.">
+
+    <!-- Customer (small, peripheral) -->
+    <div class="v4-rpam-node v4-rpam-node-customer v4-rpam-pos-customer">
+      <span class="v4-rpam-node-eyebrow">Triggers</span>
+      <span class="v4-rpam-node-label">Customer</span>
+    </div>
+
+    <!-- Lender (top-left of the cluster) -->
+    <div class="v4-rpam-node v4-rpam-node-lender v4-rpam-pos-lender">
+      <span class="v4-rpam-node-eyebrow">Originator</span>
+      <span class="v4-rpam-node-label">Lender</span>
+      <span class="v4-rpam-node-sub">Originated the loan</span>
+    </div>
+
+    <!-- Dealer (top-right) -->
+    <div class="v4-rpam-node v4-rpam-node-dealer v4-rpam-pos-dealer">
+      <span class="v4-rpam-node-eyebrow">Seller</span>
+      <span class="v4-rpam-node-label">Dealer</span>
+      <span class="v4-rpam-node-sub">Sold the ancillary product</span>
+    </div>
+
+    <!-- Allied (center, anchor) -->
+    <div class="v4-rpam-node v4-rpam-node-allied v4-rpam-pos-allied">
+      <span class="v4-rpam-node-eyebrow">Coordinator</span>
+      <span class="v4-rpam-node-label">Allied</span>
+      <span class="v4-rpam-node-sub">In the middle</span>
+    </div>
+
+    <!-- Provider (bottom) -->
+    <div class="v4-rpam-node v4-rpam-node-provider v4-rpam-pos-provider">
+      <span class="v4-rpam-node-eyebrow">Underwriter</span>
+      <span class="v4-rpam-node-label">Provider</span>
+      <span class="v4-rpam-node-sub">Cuts the refund check</span>
+    </div>
+
+    <!-- SVG flow layer: arrows + labels between the nodes -->
+    <svg class="v4-rpam-flows" viewBox="0 0 1000 720" preserveAspectRatio="xMidYMid meet"
+         aria-hidden="true" focusable="false">
+
+      <defs>
+        <!-- Two arrowhead variants: ink (data) and gold (money) -->
+        <marker id="rpam-arrow-data" viewBox="0 0 10 10" refX="9" refY="5"
+                markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="#4A443D" />
+        </marker>
+        <marker id="rpam-arrow-money" viewBox="0 0 10 10" refX="9" refY="5"
+                markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="#8A6820" />
+        </marker>
+        <marker id="rpam-arrow-status" viewBox="0 0 10 10" refX="9" refY="5"
+                markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="#6B6560" />
+        </marker>
+      </defs>
+
+      <!-- ============ DATA flows (solid, ink) ============ -->
+      <!-- Lender → Allied  (loan + cancellation data) -->
+      <path d="M 260 200 Q 380 270 460 330"
+            class="v4-rpam-flow v4-rpam-flow-data"
+            marker-end="url(#rpam-arrow-data)" />
+      <!-- Dealer → Allied  (product data) -->
+      <path d="M 740 200 Q 620 270 540 330"
+            class="v4-rpam-flow v4-rpam-flow-data"
+            marker-end="url(#rpam-arrow-data)" />
+      <!-- Allied → Provider (refund request + docs) -->
+      <path d="M 500 440 L 500 540"
+            class="v4-rpam-flow v4-rpam-flow-data"
+            marker-end="url(#rpam-arrow-data)" />
+
+      <!-- ============ MONEY flows (heavier, gold) ============ -->
+      <!-- Provider → Allied  (refund funds in) -->
+      <path d="M 470 540 L 470 440"
+            class="v4-rpam-flow v4-rpam-flow-money"
+            marker-end="url(#rpam-arrow-money)" />
+      <!-- Allied → Lender  (EFT funds out) -->
+      <path d="M 440 330 Q 340 280 240 230"
+            class="v4-rpam-flow v4-rpam-flow-money"
+            marker-end="url(#rpam-arrow-money)" />
+
+      <!-- ============ STATUS visibility (dashed, soft) ============ -->
+      <!-- Allied → Lender  (status portal) -->
+      <path d="M 460 360 Q 360 320 250 270"
+            class="v4-rpam-flow v4-rpam-flow-status"
+            marker-end="url(#rpam-arrow-status)" />
+
+      <!-- ============ Flow labels ============ -->
+      <!-- Loan + cancellation data -->
+      <g class="v4-rpam-flowlabel v4-rpam-flowlabel-data">
+        <text x="335" y="232">Loan · cancellation data</text>
+      </g>
+      <!-- Product data -->
+      <g class="v4-rpam-flowlabel v4-rpam-flowlabel-data">
+        <text x="660" y="232" text-anchor="end">Product data</text>
+      </g>
+      <!-- Refund request + docs -->
+      <g class="v4-rpam-flowlabel v4-rpam-flowlabel-data">
+        <text x="555" y="495">Refund request</text>
+      </g>
+      <!-- Refund funds -->
+      <g class="v4-rpam-flowlabel v4-rpam-flowlabel-money">
+        <text x="445" y="495" text-anchor="end">Refund funds</text>
+      </g>
+      <!-- EFT to lender -->
+      <g class="v4-rpam-flowlabel v4-rpam-flowlabel-money">
+        <text x="335" y="295">EFT to lender</text>
+      </g>
+      <!-- Status portal (italic, status flow) -->
+      <g class="v4-rpam-flowlabel v4-rpam-flowlabel-status">
+        <text x="335" y="345">Status portal (real-time)</text>
+      </g>
+    </svg>
+
+    <!-- Legend keyed to the three flow kinds -->
+    <ul class="v4-rpam-legend" aria-label="Legend">
+      <li class="v4-rpam-legend-item">
+        <span class="v4-rpam-legend-swatch v4-rpam-legend-swatch-data" aria-hidden="true"></span>
+        <span class="v4-rpam-legend-text">Data flow</span>
+      </li>
+      <li class="v4-rpam-legend-item">
+        <span class="v4-rpam-legend-swatch v4-rpam-legend-swatch-money" aria-hidden="true"></span>
+        <span class="v4-rpam-legend-text">Money flow</span>
+      </li>
+      <li class="v4-rpam-legend-item">
+        <span class="v4-rpam-legend-swatch v4-rpam-legend-swatch-status" aria-hidden="true"></span>
+        <span class="v4-rpam-legend-text">Status visibility</span>
+      </li>
+    </ul>
+  </div>
+
+  <!-- Mobile-only flow stack: lays the same content out as a vertical list -->
+  <ol class="v4-rpam-stack" aria-label="The four actor types and their flows, listed top to bottom">
+    <li class="v4-rpam-stack-item v4-rpam-node v4-rpam-node-lender">
+      <span class="v4-rpam-node-eyebrow">Originator</span>
+      <span class="v4-rpam-node-label">Lender</span>
+      <span class="v4-rpam-node-sub">Originated the loan; receives EFT; sees status in real time</span>
+    </li>
+    <li class="v4-rpam-stack-arrow" aria-hidden="true">
+      <span class="v4-rpam-stack-arrow-data">Loan + cancellation data</span>
+    </li>
+    <li class="v4-rpam-stack-item v4-rpam-node v4-rpam-node-allied">
+      <span class="v4-rpam-node-eyebrow">Coordinator</span>
+      <span class="v4-rpam-node-label">Allied</span>
+      <span class="v4-rpam-node-sub">In the middle. Receives data from lender + dealer, routes refund request to provider, returns funds + status to lender.</span>
+    </li>
+    <li class="v4-rpam-stack-arrow" aria-hidden="true">
+      <span class="v4-rpam-stack-arrow-data">Product data (from Dealer)</span>
+    </li>
+    <li class="v4-rpam-stack-item v4-rpam-node v4-rpam-node-dealer">
+      <span class="v4-rpam-node-eyebrow">Seller</span>
+      <span class="v4-rpam-node-label">Dealer</span>
+      <span class="v4-rpam-node-sub">Sold the ancillary product; holds the data Allied needs to refund</span>
+    </li>
+    <li class="v4-rpam-stack-arrow" aria-hidden="true">
+      <span class="v4-rpam-stack-arrow-money">Refund funds ↑ · Refund request ↓</span>
+    </li>
+    <li class="v4-rpam-stack-item v4-rpam-node v4-rpam-node-provider">
+      <span class="v4-rpam-node-eyebrow">Underwriter</span>
+      <span class="v4-rpam-node-label">Provider</span>
+      <span class="v4-rpam-node-sub">Underwrites the ancillary product and issues the refund</span>
+    </li>
+  </ol>
+
+  <figcaption class="v4-rpam-caption">
+    <em>The four actor types in RefundPlus and the data and money flows between them. Allied sits in the middle, coordinating between lender, dealer, and provider.</em>
+  </figcaption>
+</figure>
+
+<style>
+  /* ============ Outer figure ============ */
+  .v4-rpam {
+    margin: 3rem 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+  }
+
+  /* ============ Desktop diagram surface ============ */
+  .v4-rpam-diagram {
+    position: relative;
+    background: var(--cream, #F4EDE4);
+    border-left: 3px solid var(--gold, #C8943E);
+    border-radius: 4px;
+    padding: 2rem 2rem 1.5rem;
+    /* Lock an aspect-ratio for the SVG flow layer; node positions are
+       grid-driven so they stay aligned to the SVG geometry. */
+    aspect-ratio: 1000 / 720;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-rows: auto 1fr auto;
+    gap: 16px;
+    align-items: center;
+    justify-items: center;
+  }
+
+  /* ============ SVG flow layer sits underneath the nodes ============ */
+  .v4-rpam-flows {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+  }
+  .v4-rpam-flow {
+    fill: none;
+    stroke-linecap: round;
+  }
+  .v4-rpam-flow-data {
+    stroke: var(--charcoal-mid, #4A443D);
+    stroke-width: 1.8;
+  }
+  .v4-rpam-flow-money {
+    stroke: var(--gold-text, #8A6820);
+    stroke-width: 2.6;
+  }
+  .v4-rpam-flow-status {
+    stroke: var(--charcoal-soft, #6B6560);
+    stroke-width: 1.4;
+    stroke-dasharray: 4 5;
+  }
+
+  .v4-rpam-flowlabel text {
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 13px;
+    letter-spacing: 0.04em;
+    fill: var(--charcoal-mid, #4A443D);
+  }
+  .v4-rpam-flowlabel-money text {
+    fill: var(--gold-text, #8A6820);
+    font-weight: 600;
+  }
+  .v4-rpam-flowlabel-status text {
+    fill: var(--charcoal-soft, #6B6560);
+    font-style: italic;
+  }
+
+  /* ============ Nodes (shared) ============ */
+  .v4-rpam-node {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    border-radius: 8px;
+    padding: 0.85rem 1.05rem 1rem;
+    box-shadow: 0 1px 0 rgba(42, 37, 32, 0.08);
+    min-width: 0;
+  }
+  .v4-rpam-node-eyebrow {
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 10px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    font-weight: 700;
+    opacity: 0.85;
+    margin-bottom: 4px;
+  }
+  .v4-rpam-node-label {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 22px;
+    line-height: 1.1;
+    font-weight: 700;
+    letter-spacing: -0.005em;
+  }
+  .v4-rpam-node-sub {
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 12px;
+    line-height: 1.35;
+    margin-top: 4px;
+    opacity: 0.9;
+    max-width: 18ch;
+  }
+
+  /* ============ Per-actor color treatments ============ */
+  /* Allied — charcoal anchor, largest */
+  .v4-rpam-node-allied {
+    background: var(--charcoal, #2A2520);
+    color: var(--cream, #F4EDE4);
+    padding: 1.1rem 1.5rem 1.25rem;
+    border: 2px solid var(--charcoal, #2A2520);
+    box-shadow: 0 4px 14px rgba(42, 37, 32, 0.18);
+  }
+  .v4-rpam-node-allied .v4-rpam-node-label { font-size: 26px; }
+  .v4-rpam-node-allied .v4-rpam-node-eyebrow { color: var(--gold-light, #D4A85A); }
+
+  /* Lender — sage */
+  .v4-rpam-node-lender {
+    background: #8B9A7E;
+    color: #FFFFFF;
+  }
+  .v4-rpam-node-lender .v4-rpam-node-eyebrow { color: rgba(255,255,255,0.85); }
+
+  /* Dealer — rust */
+  .v4-rpam-node-dealer {
+    background: #B85C3A;
+    color: #FFFFFF;
+  }
+  .v4-rpam-node-dealer .v4-rpam-node-eyebrow { color: rgba(255,255,255,0.85); }
+
+  /* Provider — gold */
+  .v4-rpam-node-provider {
+    background: #C8943E;
+    color: #2A2520;
+  }
+  .v4-rpam-node-provider .v4-rpam-node-eyebrow { color: #5C4318; }
+
+  /* Customer — neutral peripheral chip */
+  .v4-rpam-node-customer {
+    background: var(--cream-deep, #EBE1D4);
+    color: var(--charcoal-mid, #4A443D);
+    padding: 0.45rem 0.8rem 0.55rem;
+    border: 1px dashed var(--charcoal-soft, #6B6560);
+    border-radius: 999px;
+  }
+  .v4-rpam-node-customer .v4-rpam-node-eyebrow {
+    font-size: 9px;
+    margin-bottom: 2px;
+    color: var(--charcoal-soft, #6B6560);
+  }
+  .v4-rpam-node-customer .v4-rpam-node-label {
+    font-size: 14px;
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-weight: 600;
+  }
+
+  /* ============ Grid positions (desktop) ============ */
+  .v4-rpam-pos-lender    { grid-column: 1; grid-row: 1; justify-self: start; }
+  .v4-rpam-pos-dealer    { grid-column: 3; grid-row: 1; justify-self: end; }
+  .v4-rpam-pos-allied    { grid-column: 2; grid-row: 2; }
+  .v4-rpam-pos-provider  { grid-column: 2; grid-row: 3; }
+  .v4-rpam-pos-customer  { grid-column: 1; grid-row: 1; justify-self: start; align-self: start; transform: translate(-4px, -18px); }
+
+  /* ============ Legend ============ */
+  .v4-rpam-legend {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    bottom: 1rem;
+    right: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    background: rgba(244, 237, 228, 0.85);
+    border-radius: 4px;
+    padding: 8px 10px;
+    z-index: 3;
+  }
+  .v4-rpam-legend-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    color: var(--charcoal-mid, #4A443D);
+  }
+  .v4-rpam-legend-swatch {
+    display: inline-block;
+    width: 22px;
+    height: 0;
+    border-top-style: solid;
+    border-top-width: 2px;
+  }
+  .v4-rpam-legend-swatch-data   { border-top-color: var(--charcoal-mid, #4A443D); border-top-width: 2px; }
+  .v4-rpam-legend-swatch-money  { border-top-color: var(--gold-text, #8A6820); border-top-width: 3px; }
+  .v4-rpam-legend-swatch-status { border-top-color: var(--charcoal-soft, #6B6560); border-top-style: dashed; }
+
+  /* ============ Mobile-only stack ============ */
+  .v4-rpam-stack { display: none; }
+
+  /* ============ Caption ============ */
+  .v4-rpam-caption {
+    font-family: var(--font-display, 'Petrona', Georgia, serif);
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--charcoal-mid, #4A443D);
+    margin: 0;
+    max-width: none;
+  }
+  .v4-rpam-caption em { font-style: italic; }
+
+  /* ============ Breakpoint: reflow to a vertical stack ============ */
+  @media (max-width: 720px) {
+    .v4-rpam-diagram {
+      display: none;
+    }
+    .v4-rpam-stack {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0;
+      list-style: none;
+      margin: 0;
+      padding: 1rem 0.25rem 1.25rem;
+      background: var(--cream, #F4EDE4);
+      border-left: 3px solid var(--gold, #C8943E);
+      border-radius: 4px;
+    }
+    .v4-rpam-stack-item {
+      margin: 0 0.75rem;
+    }
+    .v4-rpam-stack-item .v4-rpam-node-sub {
+      max-width: none;
+    }
+    .v4-rpam-stack-arrow {
+      align-self: center;
+      font-family: var(--font-mono, 'DM Mono', monospace);
+      font-size: 10px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--charcoal-mid, #4A443D);
+      padding: 10px 0 8px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      position: relative;
+    }
+    .v4-rpam-stack-arrow::before {
+      content: '';
+      width: 2px;
+      height: 18px;
+      background: var(--charcoal-soft, #6B6560);
+    }
+    .v4-rpam-stack-arrow::after {
+      content: '▼';
+      font-size: 9px;
+      color: var(--charcoal-soft, #6B6560);
+      line-height: 1;
+      margin-top: -4px;
+    }
+    .v4-rpam-stack-arrow-data   { color: var(--charcoal-mid, #4A443D); }
+    .v4-rpam-stack-arrow-money  { color: var(--gold-text, #8A6820); font-weight: 600; }
+  }
+
+  /* ============ Mid-range: shrink labels, keep diagram ============ */
+  @media (max-width: 1080px) and (min-width: 721px) {
+    .v4-rpam-flowlabel text { font-size: 11px; }
+    .v4-rpam-node-label { font-size: 18px; }
+    .v4-rpam-node-allied .v4-rpam-node-label { font-size: 22px; }
+    .v4-rpam-node-sub { font-size: 11px; }
+  }
+</style>

--- a/src/components/RefundPlusActorMap.astro
+++ b/src/components/RefundPlusActorMap.astro
@@ -24,6 +24,11 @@
 ---
 
 <figure class="v4-rpam" aria-label="The four actor types in RefundPlus and the data and money flows between them">
+  <header class="v4-rpam-scenario">
+    <span class="v4-rpam-scenario-label">The trigger</span>
+    <p>A customer cancels a GAP product or another ancillary auto-loan add-on before the loan term ends. That cancellation owes the customer a refund — which has to move across all four actors below: requested by the lender, sourced from the provider, coordinated by Allied, and ultimately paid back through the lender.</p>
+  </header>
+
   <div class="v4-rpam-diagram" role="img"
        aria-label="Allied sits at the center coordinating between lender, dealer, and provider. Data flows from lender and dealer into Allied; Allied passes data to the provider. Money flows from the provider through Allied back to the lender, who pays the customer. A status portal makes the process visible to the lender.">
 
@@ -31,6 +36,7 @@
     <div class="v4-rpam-node v4-rpam-node-customer v4-rpam-pos-customer">
       <span class="v4-rpam-node-eyebrow">Triggers</span>
       <span class="v4-rpam-node-label">Customer</span>
+      <span class="v4-rpam-node-sub">Cancels their GAP product mid-loan</span>
     </div>
 
     <!-- Lender (top-left of the cluster) -->
@@ -200,6 +206,33 @@
     display: flex;
     flex-direction: column;
     gap: 1.1rem;
+  }
+
+  /* ============ Scenario header (the trigger context) ============ */
+  .v4-rpam-scenario {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1rem 1.25rem;
+    border-left: 2px solid var(--gold-pale, #F0E4CC);
+    background: rgba(200, 148, 62, 0.04);
+    border-radius: 0 3px 3px 0;
+  }
+  .v4-rpam-scenario-label {
+    font-family: var(--font-mono, 'DM Mono', monospace);
+    font-size: 10px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--gold-text, #8A6820);
+    font-weight: 700;
+  }
+  .v4-rpam-scenario p {
+    margin: 0;
+    font-family: var(--font-body, 'DM Sans', sans-serif);
+    font-size: 14px;
+    line-height: 1.55;
+    color: var(--charcoal-mid, #4A443D);
+    max-width: 72ch;
   }
 
   /* ============ Desktop diagram surface ============ */

--- a/src/content/cases/allied.mdx
+++ b/src/content/cases/allied.mdx
@@ -24,6 +24,7 @@ import Placeholder from '../../components/Placeholder.astro';
 import BlueprintSlice from '../../components/BlueprintSlice.astro';
 import PullQuote from '../../components/PullQuote.astro';
 import Figure from '../../components/Figure.astro';
+import RefundPlusActorMap from '../../components/RefundPlusActorMap.astro';
 
 <StatRow variant="dark" stats={[
   { value: '9 months', label: 'Engagement length' },
@@ -39,17 +40,7 @@ Allied came to Harmonic Design with a sharp brief: turn a bootstrapped pilot int
 
 The complication was that no one inside Allied owned the whole picture. RefundPlus moves data and money across four kinds of actor: the lender who originated the loan, the dealer who sold the ancillary product, the provider who underwrites it, and Allied itself in the middle. Each one held part of the truth. None of them held all of it.
 
-<Placeholder
-  kind="image"
-  size="in-body-figure"
-  ask="Simple diagram of the four actors (lender, dealer, provider, Allied) and the data and money flows between them"
-  why="The prose names four actor types abstractly; one diagram lets the reader hold the whole system in mind before the case turns on its coordination problem"
-  alternatives={[
-    "Crop the actor swim lanes from the Experience Map or the service blueprint header",
-    "Skip; the prose carries the multi-actor framing well enough on its own"
-  ]}
-  source="visual-director-recommendation"
-/>
+<RefundPlusActorMap />
 
 ## What the service had grown into
 


### PR DESCRIPTION
## Summary

Replaces the candidate-thumbnails Placeholder in the allied case with a custom four-actor diagram. The top match (Research Findings p8) had the right content but Whitney's feedback was that each actor needed to be visually distinct via color and shape, not just a redrawn flow.

## What's in this PR

- New: `src/components/RefundPlusActorMap.astro` — four-actor diagram, Allied at center, distinct portfolio-palette colors per actor (charcoal / sage / rust / gold) plus a peripheral Customer chip; labeled data, money, and status-visibility flows; pure HTML/CSS/SVG (no JS); responsive — reflows to a vertical stack on mobile.
- Modified: `src/content/cases/allied.mdx` — replaces the `Placeholder kind="image"` + `candidates={[...]}` block in section 1 with `<RefundPlusActorMap />`, adds the import.
- Note: the three `allied-candidate-*.png` thumbnail files referenced in the original Placeholder were never committed to main, so there are no images to remove.

## Layout chosen

- **Allied** — center (anchor, charcoal, largest node), per the case prose "Allied itself in the middle"
- **Lender** — top-left (sage) — originates the loan, drives the cancellation event
- **Dealer** — top-right (rust) — holds product data Allied pulls in
- **Provider** — bottom-center (gold) — underwriter who cuts the check
- **Customer** — small dashed chip tucked into the upper-left edge (cream-deep) — the person whose cancellation triggers everything

## Flows shown

- **Data flows** (solid ink): Lender → Allied (loan + cancellation data); Dealer → Allied (product data); Allied → Provider (refund request)
- **Money flows** (heavier gold): Provider → Allied (refund funds in); Allied → Lender (EFT)
- **Status visibility** (dashed soft-grey): Allied → Lender (status portal, real-time)

Legend keyed to those three flow kinds, anchored bottom-right of the diagram surface.

## Recovery

Pre-existing main: `whitneyesque/whitneyesque.github.io@4b1713a993a49d53e4e0edaee227d4bb3786c4ce`

## Test plan

- [ ] Cloudflare preview at /cases/allied — verify the diagram replaces the candidate-thumbnails Placeholder
- [ ] Confirm each actor is in a distinct, identifiable color (Allied charcoal, Lender sage, Dealer rust, Provider gold, Customer neutral)
- [ ] Confirm the data / money / status flows are legible and the legend matches
- [ ] Confirm responsive layout — diagram on desktop, vertical stack with arrow indicators on mobile (<=720px)